### PR TITLE
Initial commit of v0.1.0

### DIFF
--- a/account-info-nz-changelog.md
+++ b/account-info-nz-changelog.md
@@ -2,6 +2,11 @@
 
 ---
 
+## v0.1.0 - 23/03/2018
+
+* Changed base path to /open-banking/v0.1
+* Version bump specification to v0.1.0 to reflect MINOR change to stabilise for pilot
+
 ## V0.0.3 - 16/02/2018
 
 * Added AccountRequestResponseModel - this model wraps the AccountRequestModel (model of account access requests) and adds the required response fields.  Previously this was done through read-only attributes, however this causes semantic error when used with 'required'.  The AccountRequestsResponseModel is syntactically equivalent, allows for required fields and removes the error condition.

--- a/account-info-nz-swagger.yaml
+++ b/account-info-nz-swagger.yaml
@@ -12,8 +12,8 @@ info:
   license:
     name: Licence
     url: 'https://www.paymentsnz.co.nz/contact-us'
-  version: v0.0.3
-basePath: /open-banking/v1
+  version: v0.1.0
+basePath: /open-banking/v0.1
 schemes:
   - https
 produces:


### PR DESCRIPTION
At the request of the standards sub-group I have bumped the version of the API specification to v0.1.0 and reflected this in the API base path.