### PR TITLE
Remove products endpoint

### DIFF
--- a/account-info-nz-swagger.yaml
+++ b/account-info-nz-swagger.yaml
@@ -2177,7 +2177,6 @@ definitions:
             - ReadPAN
             - ReadParty
             - ReadPartyPSU
-            - ReadProducts
             - ReadScheduledPaymentsBasic
             - ReadScheduledPaymentsDetail
             - ReadStandingOrdersBasic


### PR DESCRIPTION
As per the decision on 8/02/2019, the 'products' endpoints have been removed.  The permission of 'ReadProducts' has also been removed from the account-requests permission enum.