### PR TITLE
Changed cardinality on account-statements by ID

### DIFF
--- a/working/v2.0.0-draft3/account-info-nz-swagger.yaml
+++ b/working/v2.0.0-draft3/account-info-nz-swagger.yaml
@@ -995,9 +995,7 @@ paths:
                 type: object
                 properties:
                   Statement:
-                    items:
-                      $ref: '#/definitions/StatementModel'
-                    type: array
+                    $ref: '#/definitions/StatementModel'
                     description: Provides further details on a statement resource.
                 additionalProperties: false
               Links:


### PR DESCRIPTION
Update the /accounts/{AccountId}/statements/{StatementId} to return a single object rather than multiple.  This aligns with the /accounts/{AccountId} singular return.  This is a decision made by the API Centre Technical Working Group on 8/11/2019.

It should be noted that this differs from the OBIE standard.