### PR TITLE
Corrected AccountSubType enum to match published values

### DIFF
--- a/working/v3.0.0-rc1/account-info-nz-openapi.yaml
+++ b/working/v3.0.0-rc1/account-info-nz-openapi.yaml
@@ -2216,13 +2216,9 @@ components:
           description: Specifies the sub type of account (product family group).
           type: string
           enum:
-            - ChargeCard
             - CreditCard
-            - CurrentAccount
-            - EMoney
-            - Loan
-            - Mortgage
-            - PrePaidCard
+            - Lending
+            - Transaction
             - Savings
         Description:
           description: Specifies the description of the account type.


### PR DESCRIPTION
The account subtype values in the OpenAPI specification were different to those on the confluence pages.  This PR is to correct that oversight.