### PR TITLE
Risk statements update

### DIFF
--- a/working/v3.0.0-rc2/account-info-nz-openapi.yaml
+++ b/working/v3.0.0-rc2/account-info-nz-openapi.yaml
@@ -2425,6 +2425,16 @@ components:
           type: string
           minLength: 1
           maxLength: 14
+        EndUserCompanyName:
+          description: Name of the end user facing organisation
+          type: string
+          minLength: 1
+          maxLength: 70
+        EndUserCompanyNZBN:
+          description: NZ business number for the end user facing organisation
+          type: string
+          minLength: 1
+          maxLength: 70
         MerchantName:
           description: Name of the merchant
           type: string

--- a/working/v3.0.0-rc2/account-info-nz-openapi.yaml
+++ b/working/v3.0.0-rc2/account-info-nz-openapi.yaml
@@ -2329,12 +2329,12 @@ components:
           type: object
           properties:
             Latitude:
-              description: Latitude measured in decimal degress
+              description: Latitude measured in decimal degrees
               type: string
               maxLength: 14
               pattern: ^-?\d{1,3}\.\d{1,8}$
             Longitude:
-              description: Longitude measured in decimal degress
+              description: Longitude measured in decimal degrees
               type: string
               maxLength: 14
               pattern: ^-?\d{1,3}\.\d{1,8}$
@@ -2990,7 +2990,7 @@ components:
             - Identification
           additionalProperties: false
           description: Unambiguous identification of the account of the debtor, in the
-            case of a crebit transaction.
+            case of a credit transaction.
       required:
         - AccountId
         - Amount

--- a/working/v3.0.0-rc2/account-info-nz-openapi.yaml
+++ b/working/v3.0.0-rc2/account-info-nz-openapi.yaml
@@ -988,8 +988,6 @@ paths:
       parameters:
         - $ref: "#/components/parameters/AccountIdParam"
         - $ref: "#/components/parameters/StatementIdParam"
-        - $ref: "#/components/parameters/FromStatementDateTimeParam"
-        - $ref: "#/components/parameters/ToStatementDateTimeParam"
         - $ref: "#/components/parameters/x-fapi-auth-date-Param"
         - $ref: "#/components/parameters/x-fapi-customer-ip-address-Param"
         - $ref: "#/components/parameters/x-fapi-interaction-id-Param"


### PR DESCRIPTION
As per the TWG [tech decision 050](https://paymentsnz.atlassian.net/wiki/spaces/PaymentsDirectionAPIStandardsDevelopment/pages/1659109377/Technical+Decision+-+050+-+Risk+object+additional+parties), Risk object has been updated to include `EndUserCompanyName` and `EndUserCompanyNZBN` as optional fields.    Further, per the discussion on the meeting on 6th October 2023, filtering is being removed from the single-resource Statement endpoint.

Also correcting spelling mistakes as per JIRA [item 701](https://paymentsnz.atlassian.net/browse/PNZAC-701) ahead of investigating previous versions.