### PR TITLE
Error response body correction

### DIFF
--- a/working/README.md
+++ b/working/README.md
@@ -4,7 +4,7 @@ The version folder is used to keep work-in-progress draft specs.
 
 ## Linting and spell checking
 
-API specifications are checked with `cspell` for spelling errors, and with Redocly CLI linter for correctness.  While never a 100% guarantee of correctness, these help find issues associated with chanegs to the OpenAPI specifications.
+API specifications are checked with `cspell` for spelling errors, and with Redocly CLI linter for correctness.  While never a 100% guarantee of correctness, these help find issues associated with changes to the OpenAPI specifications.
 
 The [linter configuration](api-lint-config.yaml) contains rules that extend Redocly's `recommended` set of linting rules. To use this run the following command (with path to OpenAPI specification):
 

--- a/working/v3.0.0-rc2/account-info-nz-openapi.yaml
+++ b/working/v3.0.0-rc2/account-info-nz-openapi.yaml
@@ -1901,6 +1901,10 @@ components:
           description: An RFC4122 UID used as a correlation id.
           schema:
             type: string
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
     403ErrorResponse:
       description: Forbidden
       headers:
@@ -1919,6 +1923,10 @@ components:
           description: An RFC4122 UID used as a correlation id.
           schema:
             type: string
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
     406ErrorResponse:
       description: Not Acceptable
       headers:
@@ -1926,6 +1934,10 @@ components:
           description: An RFC4122 UID used as a correlation id.
           schema:
             type: string
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
     415ErrorResponse:
       description: Unsupported Media Type
       headers:
@@ -1933,6 +1945,10 @@ components:
           description: An RFC4122 UID used as a correlation id.
           schema:
             type: string
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
     429ErrorResponse:
       description: Too Many Requests
       headers:
@@ -1944,6 +1960,10 @@ components:
           description: An RFC4122 UID used as a correlation id.
           schema:
             type: string
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
     500ErrorResponse:
       description: Internal Server Error
       headers:
@@ -1962,6 +1982,10 @@ components:
           description: An RFC4122 UID used as a correlation id.
           schema:
             type: string
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
     503ErrorResponse:
       description: Service Unavailable
       headers:


### PR DESCRIPTION
It has been noted in [JIRA PNZAC-704](https://paymentsnz.atlassian.net/jira/servicedesk/projects/PNZAC/queues/custom/17/PNZAC-704) that [technical decision 029](https://paymentsnz.atlassian.net/wiki/spaces/PaymentsDirectionAPIStandardsDevelopment/pages/1455358006/Technical+Decision+-+029+-+Error+Response+Body+Inconsistency) is not reflected in OpenAPI specification.  Technical decision 029 concluded that *all* non-success error codes (i.e. 4xx and 5xx HTTP responses) *must* have the standard error response body.

This pull request corrects the OpenAPI to align with the technical decision and API specifications as documented.