### PR TITLE
Patch to include error response body

### DIFF
--- a/account-info-nz-changelog.md
+++ b/account-info-nz-changelog.md
@@ -2,6 +2,10 @@
 
 ---
 
+## v2.1.2, v2.2.2, v2.3.2 - 25/10/2023
+
+- Patch release to update all HTTP error responses to include standard error body.  This aligns with the documented requirement and Technical Working Group decision 029.
+
 ## v2.0.2, v2.1.1, v2.2.1, v2.3.1 - 04/11/2022
 
 - Patch release to add `additionalProperties: false` to BECSRemittance DebtorReference and CreditorReference sub-schemas.  This prevents the possibility of additional JSON member values being supplied

--- a/dist/v2.1.2/Readme.md
+++ b/dist/v2.1.2/Readme.md
@@ -1,7 +1,7 @@
 # Account Information API
 
-## V2.1.1
+## V2.1.2
 
-This is v2.1.1 NZ Open Banking Account Information API technical specification.
+This is v2.1.2 NZ Open Banking Account Information API technical specification.
 
 The Swagger 2.0 document is [here](account-info-nz-swagger.yaml).

--- a/dist/v2.1.2/Readme.md
+++ b/dist/v2.1.2/Readme.md
@@ -1,0 +1,7 @@
+# Account Information API
+
+## V2.1.1
+
+This is v2.1.1 NZ Open Banking Account Information API technical specification.
+
+The Swagger 2.0 document is [here](account-info-nz-swagger.yaml).

--- a/dist/v2.1.2/account-info-nz-swagger.yaml
+++ b/dist/v2.1.2/account-info-nz-swagger.yaml
@@ -12,7 +12,7 @@ info:
   license:
     name: Licence
     url: "https://www.apicentre.paymentsnz.co.nz/join/"
-  version: v2.1.1
+  version: v2.1.2
 basePath: /open-banking-nz/v2.1
 schemes:
   - https
@@ -42,7 +42,7 @@ tags:
       on a specific account
   - name: Offers
     description: >-
-      A set of elements that descirbe the list of offers avaialble to a specific
+      A set of elements that describe the list of offers available to a specific
       account
   - name: Party
     description: >-
@@ -2219,12 +2219,12 @@ definitions:
         type: object
         properties:
           Latitude:
-            description: Latitude measured in decimal degress
+            description: Latitude measured in decimal degrees
             type: string
             maxLength: 14
             pattern: '^-?\d{1,3}\.\d{1,8}$'
           Longitude:
-            description: Longitude measured in decimal degress
+            description: Longitude measured in decimal degrees
             type: string
             maxLength: 14
             pattern: '^-?\d{1,3}\.\d{1,8}$'
@@ -2965,7 +2965,7 @@ definitions:
         additionalProperties: false
         description: >-
           Unambiguous identification of the account of the debtor, in the case
-          of a crebit transaction.
+          of a credit transaction.
     required:
       - AccountId
       - Amount
@@ -4389,6 +4389,8 @@ responses:
       x-fapi-interaction-id:
         type: string
         description: An RFC4122 UID used as a correlation id.
+    schema:
+      $ref: "#/definitions/ErrorResponse"
   403ErrorResponse:
     description: Forbidden
     headers:
@@ -4403,18 +4405,24 @@ responses:
       x-fapi-interaction-id:
         type: string
         description: An RFC4122 UID used as a correlation id.
+    schema:
+      $ref: "#/definitions/ErrorResponse"
   406ErrorResponse:
     description: Not Acceptable
     headers:
       x-fapi-interaction-id:
         type: string
         description: An RFC4122 UID used as a correlation id.
+    schema:
+      $ref: "#/definitions/ErrorResponse"
   415ErrorResponse:
     description: Unsupported Media Type
     headers:
       x-fapi-interaction-id:
         type: string
         description: An RFC4122 UID used as a correlation id.
+    schema:
+      $ref: "#/definitions/ErrorResponse"
   429ErrorResponse:
     description: Too Many Requests
     headers:
@@ -4424,6 +4432,8 @@ responses:
       x-fapi-interaction-id:
         type: string
         description: An RFC4122 UID used as a correlation id.
+    schema:
+      $ref: "#/definitions/ErrorResponse"
   500ErrorResponse:
     description: Internal Server Error
     headers:
@@ -4438,6 +4448,8 @@ responses:
       x-fapi-interaction-id:
         type: string
         description: An RFC4122 UID used as a correlation id.
+    schema:
+      $ref: "#/definitions/ErrorResponse"
   503ErrorResponse:
     description: Service Unavailable
     headers:

--- a/dist/v2.1.2/account-info-nz-swagger.yaml
+++ b/dist/v2.1.2/account-info-nz-swagger.yaml
@@ -1,0 +1,4448 @@
+swagger: "2.0"
+info:
+  title: Account and Transaction API Specification
+  description: >-
+    Swagger for Account and Transaction API Specification. This is heavily
+    derived from the Open Banking UK API - see www.openbanking.org.uk for
+    details.
+  termsOfService: "https://www.apicentre.paymentsnz.co.nz/contact-us/"
+  contact:
+    name: Payments NZ API Centre
+    email: apicentre@paymentsnz.co.nz
+  license:
+    name: Licence
+    url: "https://www.apicentre.paymentsnz.co.nz/join/"
+  version: v2.1.1
+basePath: /open-banking-nz/v2.1
+schemes:
+  - https
+consumes:
+  - application/json; charset=utf-8
+produces:
+  - application/json; charset=utf-8
+tags:
+  - name: Account Access Consents
+    description: >-
+      A consent to access account information resources
+  - name: Accounts
+    description: >-
+      A resource that represents the account to which credit and debit entries are
+      made
+  - name: Balances
+    description: >-
+      A resource that represents the net increases and decreases in an account at a
+      specific point in time
+  - name: Beneficiaries
+    description: >-
+      A set of elements that describe the list of trusted beneficiaries linked to a
+      specific account
+  - name: Direct Debits
+    description: >-
+      A set of elements that describe the list of direct-debits that have been set up
+      on a specific account
+  - name: Offers
+    description: >-
+      A set of elements that descirbe the list of offers avaialble to a specific
+      account
+  - name: Party
+    description: >-
+      A set of elements that describe the party linked to a specific account
+  - name: Scheduled Payments
+    description: >-
+      A set of elements that describe the list of scheduled-payments that have been
+      set up on a specific account
+  - name: Standing Orders
+    description: >-
+      A set of elements that describe the list of standing-orders that have been set
+      up on a specific account
+  - name: Statements
+    description: >-
+      A resource that describes summary details for an account statement period
+  - name: Transactions
+    description: >-
+      A resource that describes a posting to an account that results in an increase
+      or decrease to a balance
+paths:
+  "/account-access-consents":
+    post:
+      tags:
+        - Account Access Consents
+      operationId: CreateAccountAccessConsent
+      summary: Create an account access consent
+      description: >-
+        The account-access-consents resource represents a consent that has been
+        agreed between the Customer and the Third Party for the Third Party to
+        access a Customer's account information with an API Provider.
+      parameters:
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+        - name: body
+          in: body
+          description: Account Access Consent Body
+          required: true
+          schema:
+            title: Account Access Consent
+            type: object
+            properties:
+              Data:
+                $ref: "#/definitions/AccountAccessConsentModel"
+              Risk:
+                $ref: "#/definitions/Risk"
+            required:
+              - Data
+              - Risk
+            additionalProperties: false
+      responses:
+        "201":
+          description: Account Access Consent successfully created
+          schema:
+            title: Account Access Consent POST response
+            type: object
+            properties:
+              Data:
+                $ref: "#/definitions/AccountAccessConsentResponseModel"
+              Risk:
+                $ref: "#/definitions/Risk"
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Risk
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "415":
+          $ref: "#/responses/415ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - ThirdPartyOAuth2Security:
+            - accounts
+  "/account-access-consents/{ConsentId}":
+    get:
+      tags:
+        - Account Access Consents
+      operationId: GetAccountAccessConsent
+      summary: Get an account access consent
+      description: Retrieve an account access consent and check its status.
+      parameters:
+        - $ref: "#/parameters/ConsentIdParam"
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account Access Consent successfully retrieved
+          schema:
+            title: Account Access Consent GET response
+            type: object
+            properties:
+              Data:
+                $ref: "#/definitions/AccountAccessConsentResponseModel"
+              Risk:
+                $ref: "#/definitions/Risk"
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Risk
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - ThirdPartyOAuth2Security:
+            - accounts
+    delete:
+      tags:
+        - Account Access Consents
+      operationId: DeleteAccountAccessConsent
+      summary: Delete an account access consent
+      description: Delete an account access consent
+      parameters:
+        - $ref: "#/parameters/ConsentIdParam"
+        - $ref: "#/parameters/AuthorizationParam"
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+      responses:
+        "204":
+          description: Account Access Consent successfully deleted
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - ThirdPartyOAuth2Security:
+            - accounts
+  "/accounts":
+    get:
+      tags:
+        - Accounts
+      operationId: GetAccounts
+      summary: Get Accounts
+      description: Get a list of accounts
+      parameters:
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Accounts successfully retrieved
+          schema:
+            title: Account GET response
+            type: object
+            properties:
+              Data:
+                title: Data
+                type: object
+                description: Data
+                properties:
+                  Account:
+                    title: Account
+                    description: Account
+                    type: array
+                    items:
+                      $ref: "#/definitions/AccountModel"
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/accounts/{AccountId}":
+    get:
+      tags:
+        - Accounts
+      operationId: GetAccount
+      summary: Get Account
+      description: Get an account
+      parameters:
+        - $ref: "#/parameters/AccountIdParam"
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account resource successfully retrieved
+          schema:
+            title: Account GET response
+            type: object
+            properties:
+              Data:
+                title: Data
+                description: Data
+                type: object
+                properties:
+                  Account:
+                    $ref: "#/definitions/AccountModel"
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/accounts/{AccountId}/transactions":
+    get:
+      tags:
+        - Transactions
+      operationId: GetAccountTransactions
+      summary: Get Account Transactions
+      description: Get transactions related to an account
+      parameters:
+        - $ref: "#/parameters/AccountIdParam"
+        - $ref: "#/parameters/FromBookingDateTimeParam"
+        - $ref: "#/parameters/ToBookingDateTimeParam"
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account Transactions successfully retrieved
+          schema:
+            title: Transactions GET response
+            type: object
+            properties:
+              Data:
+                title: Data
+                description: Data
+                type: object
+                properties:
+                  Transaction:
+                    title: Transaction
+                    description: Transaction
+                    type: array
+                    items:
+                      $ref: "#/definitions/TransactionModel"
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/accounts/{AccountId}/beneficiaries":
+    get:
+      tags:
+        - Beneficiaries
+      operationId: GetAccountBeneficiaries
+      summary: Get Account Beneficiaries
+      description: Get Beneficiaries related to an account
+      parameters:
+        - $ref: "#/parameters/AccountIdParam"
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account Beneficiaries  successfully retrieved
+          schema:
+            title: Beneficiaries GET response
+            type: object
+            properties:
+              Data:
+                title: Data
+                description: Data
+                type: object
+                properties:
+                  Beneficiary:
+                    title: Beneficiary
+                    description: Beneficiary
+                    type: array
+                    items:
+                      $ref: "#/definitions/BeneficiaryModel"
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/accounts/{AccountId}/balances":
+    get:
+      tags:
+        - Balances
+      operationId: GetAccountBalances
+      summary: Get Account Balances
+      description: Get Balances related to an account
+      parameters:
+        - $ref: "#/parameters/AccountIdParam"
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account Balances successfully retrieved
+          schema:
+            title: Balances GET response
+            type: object
+            properties:
+              Data:
+                title: Data
+                description: Data
+                type: object
+                properties:
+                  Balance:
+                    title: Balance
+                    description: Balance
+                    type: array
+                    items:
+                      $ref: "#/definitions/BalanceModel"
+                required:
+                  - Balance
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/accounts/{AccountId}/direct-debits":
+    get:
+      tags:
+        - Direct Debits
+      operationId: GetAccountDirectDebits
+      summary: Get Account Direct Debits
+      description: Get Direct Debits related to an account
+      parameters:
+        - $ref: "#/parameters/AccountIdParam"
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account Direct Debits successfully retrieved
+          schema:
+            title: Direct Debit GET response
+            type: object
+            properties:
+              Data:
+                title: Data
+                description: Data
+                type: object
+                properties:
+                  DirectDebit:
+                    title: DirectDebit
+                    description: DirectDebit
+                    type: array
+                    items:
+                      $ref: "#/definitions/DirectDebitModel"
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/accounts/{AccountId}/standing-orders":
+    get:
+      tags:
+        - Standing Orders
+      operationId: GetAccountStandingOrders
+      summary: Get Account Standing Orders
+      description: Get Standing Orders related to an account
+      parameters:
+        - $ref: "#/parameters/AccountIdParam"
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account Standing Orders successfully retrieved
+          schema:
+            title: Standing Orders GET response
+            type: object
+            properties:
+              Data:
+                title: Data
+                description: Data
+                type: object
+                properties:
+                  StandingOrder:
+                    title: StandingOrder
+                    description: StandingOrder
+                    type: array
+                    items:
+                      $ref: "#/definitions/StandingOrderModel"
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/accounts/{AccountId}/offers":
+    get:
+      tags:
+        - Offers
+      operationId: GetAccountOffers
+      summary: Get Account Offers
+      description: Get Offers related to an account
+      parameters:
+        - $ref: "#/parameters/AccountIdParam"
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account Offers successfully retrieved
+          schema:
+            type: object
+            properties:
+              Data:
+                type: object
+                properties:
+                  Offer:
+                    items:
+                      $ref: "#/definitions/OfferModel"
+                    type: array
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/accounts/{AccountId}/party":
+    get:
+      tags:
+        - Party
+      operationId: GetAccountParty
+      summary: Get Account Party
+      description: Get Party related to an account
+      parameters:
+        - $ref: "#/parameters/AccountIdParam"
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account Party successfully retrieved
+          schema:
+            type: object
+            properties:
+              Data:
+                type: object
+                properties:
+                  Party:
+                    $ref: "#/definitions/PartyModel"
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/accounts/{AccountId}/scheduled-payments":
+    get:
+      tags:
+        - Scheduled Payments
+      operationId: GetAccountScheduledPayments
+      summary: Get Account Scheduled Payments
+      description: Get Scheduled Payments related to an account
+      parameters:
+        - $ref: "#/parameters/AccountIdParam"
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account Scheduled Payment successfully retrieved
+          schema:
+            type: object
+            properties:
+              Data:
+                type: object
+                properties:
+                  ScheduledPayment:
+                    items:
+                      $ref: "#/definitions/ScheduledPaymentModel"
+                    type: array
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/accounts/{AccountId}/statements":
+    get:
+      tags:
+        - Statements
+      operationId: GetAccountStatements
+      summary: Get Account Statements
+      description: Get Statements related to an account
+      parameters:
+        - $ref: "#/parameters/AccountIdParam"
+        - $ref: "#/parameters/FromStatementDateTimeParam"
+        - $ref: "#/parameters/ToStatementDateTimeParam"
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account Statement successfully retrieved
+          schema:
+            type: object
+            properties:
+              Data:
+                type: object
+                properties:
+                  Statement:
+                    items:
+                      $ref: "#/definitions/StatementModel"
+                    type: array
+                    description: Provides further details on a statement resource.
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/accounts/{AccountId}/statements/{StatementId}":
+    get:
+      tags:
+        - Statements
+      operationId: GetAccountStatement
+      summary: Get Statement
+      description: Get Statement related to an account
+      parameters:
+        - $ref: "#/parameters/AccountIdParam"
+        - $ref: "#/parameters/StatementIdParam"
+        - $ref: "#/parameters/FromStatementDateTimeParam"
+        - $ref: "#/parameters/ToStatementDateTimeParam"
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account Statement successfully retrieved
+          schema:
+            type: object
+            properties:
+              Data:
+                type: object
+                properties:
+                  Statement:
+                    $ref: "#/definitions/StatementModel"
+                    description: Provides further details on a statement resource.
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/accounts/{AccountId}/statements/{StatementId}/file":
+    get:
+      tags:
+        - Statements
+      operationId: GetAccountStatementFile
+      summary: Get Statement File
+      description: Get Statement related to an account
+      produces:
+        - "*/*"
+      parameters:
+        - $ref: "#/parameters/AccountIdParam"
+        - $ref: "#/parameters/StatementIdParam"
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account Statement File successfully retrieved
+          schema:
+            type: file
+            description: Statement File
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/accounts/{AccountId}/statements/{StatementId}/transactions":
+    get:
+      tags:
+        - Statements
+        - Transactions
+      operationId: GetAccountStatementTransactions
+      summary: Get Statement Transactions
+      description: Get Statement Transactions related to an account
+      parameters:
+        - $ref: "#/parameters/AccountIdParam"
+        - $ref: "#/parameters/StatementIdParam"
+        - $ref: "#/parameters/FromBookingDateTimeParam"
+        - $ref: "#/parameters/ToBookingDateTimeParam"
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account Transactions successfully retrieved
+          schema:
+            type: object
+            properties:
+              Data:
+                type: object
+                properties:
+                  Transaction:
+                    items:
+                      $ref: "#/definitions/TransactionModel"
+                    type: array
+                    description: Provides further details on an entry in the report.
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/standing-orders":
+    get:
+      tags:
+        - Standing Orders
+      operationId: GetStandingOrders
+      summary: Get Standing Orders
+      description: Get Standing Orders
+      parameters:
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Standing Orders successfully retrieved
+          schema:
+            title: Standing Orders GET response
+            type: object
+            properties:
+              Data:
+                title: Data
+                description: Data
+                type: object
+                properties:
+                  StandingOrder:
+                    title: StandingOrder
+                    description: StandingOrder
+                    type: array
+                    items:
+                      $ref: "#/definitions/StandingOrderModel"
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            additionalProperties: false
+            required:
+              - Data
+              - Links
+              - Meta
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/direct-debits":
+    get:
+      tags:
+        - Direct Debits
+      operationId: GetDirectDebits
+      summary: Get Direct Debits
+      description: Get Direct Debits
+      parameters:
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Direct Debits successfully retrieved
+          schema:
+            title: Direct Debit GET response
+            type: object
+            properties:
+              Data:
+                title: Data
+                description: Data
+                type: object
+                properties:
+                  DirectDebit:
+                    title: DirectDebit
+                    description: DirectDebit
+                    type: array
+                    items:
+                      $ref: "#/definitions/DirectDebitModel"
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/beneficiaries":
+    get:
+      tags:
+        - Beneficiaries
+      operationId: GetBeneficiaries
+      summary: Get Beneficiaries
+      description: Get Beneficiaries
+      parameters:
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Beneficiaries successfully retrieved
+          schema:
+            title: Beneficiaries GET response
+            type: object
+            properties:
+              Data:
+                title: Data
+                description: Data
+                type: object
+                properties:
+                  Beneficiary:
+                    title: Beneficiary
+                    description: Beneficiary
+                    type: array
+                    items:
+                      $ref: "#/definitions/BeneficiaryModel"
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/transactions":
+    get:
+      tags:
+        - Transactions
+      operationId: GetTransactions
+      summary: Get Transactions
+      description: Get Transactions
+      parameters:
+        - $ref: "#/parameters/FromBookingDateTimeParam"
+        - $ref: "#/parameters/ToBookingDateTimeParam"
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Transactions successfully retrieved
+          schema:
+            title: Transactions GET response
+            type: object
+            properties:
+              Data:
+                title: Data
+                description: Data
+                type: object
+                properties:
+                  Transaction:
+                    title: Transaction
+                    description: Transaction
+                    type: array
+                    items:
+                      $ref: "#/definitions/TransactionModel"
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/balances":
+    get:
+      tags:
+        - Balances
+      operationId: GetBalances
+      summary: Get Balances
+      description: Get Balances
+      parameters:
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Balances successfully retrieved
+          schema:
+            title: Balances GET response
+            type: object
+            properties:
+              Data:
+                title: Data
+                description: Data
+                type: object
+                properties:
+                  Balance:
+                    title: Balance
+                    description: Balance
+                    type: array
+                    items:
+                      $ref: "#/definitions/BalanceModel"
+                required:
+                  - Balance
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            additionalProperties: false
+            required:
+              - Data
+              - Links
+              - Meta
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/offers":
+    get:
+      tags:
+        - Offers
+      operationId: GetOffers
+      summary: Get Offers
+      description: Get Offers
+      parameters:
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account Offers successfully retrieved
+          schema:
+            type: object
+            properties:
+              Data:
+                type: object
+                properties:
+                  Offer:
+                    items:
+                      $ref: "#/definitions/OfferModel"
+                    type: array
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/party":
+    get:
+      tags:
+        - Party
+      operationId: GetParty
+      summary: Get Party
+      description: Get Party of logged in Customer
+      parameters:
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account Party successfully retrieved
+          schema:
+            type: object
+            properties:
+              Data:
+                type: object
+                properties:
+                  Party:
+                    $ref: "#/definitions/PartyModel"
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/scheduled-payments":
+    get:
+      tags:
+        - Scheduled Payments
+      operationId: GetScheduledPayments
+      summary: Get Scheduled Payments
+      description: Get Scheduled Payments
+      parameters:
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account Scheduled Payment successfully retrieved
+          schema:
+            type: object
+            properties:
+              Data:
+                type: object
+                properties:
+                  ScheduledPayment:
+                    items:
+                      $ref: "#/definitions/ScheduledPaymentModel"
+                    type: array
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/statements":
+    get:
+      tags:
+        - Statements
+      summary: Get Statements
+      description: Get Statements
+      operationId: GetStatements
+      parameters:
+        - $ref: "#/parameters/FromStatementDateTimeParam"
+        - $ref: "#/parameters/ToStatementDateTimeParam"
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account Statement successfully retrieved
+          schema:
+            type: object
+            properties:
+              Data:
+                type: object
+                properties:
+                  Statement:
+                    items:
+                      $ref: "#/definitions/StatementModel"
+                    type: array
+                    description: Provides further details on a statement.
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+parameters:
+  AccountIdParam:
+    name: AccountId
+    in: path
+    description: A unique identifier used to identify the account resource.
+    required: true
+    type: string
+  ConsentIdParam:
+    name: ConsentId
+    in: path
+    description: >-
+      Unique identification as assigned by the API Provider to uniquely identify the
+      account access consent.
+    required: true
+    type: string
+  FromBookingDateTimeParam:
+    in: query
+    name: fromBookingDateTime
+    type: string
+    format: date-time
+    description: >-
+      The UTC ISO 8601 Date Time to filter transactions FROM
+      NB Time component is optional - set to 00:00:00 for just Date.
+      If the Date Time contains a timezone, the API Provider must ignore the timezone
+      component.
+  StatementIdParam:
+    name: StatementId
+    in: path
+    description: A unique identifier used to identify the statement resource.
+    required: true
+    type: string
+  ToBookingDateTimeParam:
+    in: query
+    name: toBookingDateTime
+    type: string
+    format: date-time
+    description: >-
+      The UTC ISO 8601 Date Time to filter transactions TO
+      NB Time component is optional - set to 00:00:00 for just Date.
+      If the Date Time contains a timezone, the API Provider must ignore the timezone
+      component.
+  FromStatementDateTimeParam:
+    in: query
+    name: fromStatementDateTime
+    type: string
+    format: date-time
+    description: >-
+      The UTC ISO 8601 Date Time to filter statements FROM
+      NB Time component is optional - set to 00:00:00 for just Date.
+      If the Date Time contains a timezone, the API Provider must ignore the timezone
+      component.
+  ToStatementDateTimeParam:
+    in: query
+    name: toStatementDateTime
+    type: string
+    format: date-time
+    description: >-
+      The UTC ISO 8601 Date Time to filter statements TO
+      NB Time component is optional - set to 00:00:00 for just Date.
+      If the Date Time contains a timezone, the API Provider must ignore the timezone
+      component.
+  x-fapi-customer-ip-address-Param:
+    in: header
+    name: x-fapi-customer-ip-address
+    type: string
+    required: false
+    description: The Customer's IP address if the Customer is currently logged in with the Third Party.
+    pattern: ^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$
+  x-fapi-interaction-id-Param:
+    in: header
+    name: x-fapi-interaction-id
+    type: string
+    required: false
+    description: An RFC4122 UID used as a correlation id.
+  x-fapi-auth-date-Param:
+    in: header
+    name: x-fapi-auth-date
+    type: string
+    required: false
+    description: >-
+      The time when the Customer last logged in with the Third Party.
+
+      All dates in the HTTP headers are represented as RFC 7231 Full Dates. An
+      example is below:
+
+      Sun, 10 Sep 2017 19:43:31 UTC
+    pattern: >-
+      ^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), \d{2}
+      (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{4} \d{2}:\d{2}:\d{2}
+      (GMT|UTC)$
+  x-merchant-ip-address-Param:
+    in: header
+    name: x-merchant-ip-address
+    type: string
+    required: false
+    description: >-
+      The IP address of the merchant when making account information requests through a
+      Third Party.
+    pattern: ^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$
+  x-customer-user-agent-Param:
+    in: header
+    name: x-customer-user-agent
+    type: string
+    required: false
+    description: >-
+      The User-Agent of the application on the customer device that is used to
+      make the account information request
+  AuthorizationParam:
+    in: header
+    name: Authorization
+    type: string
+    required: true
+    description: "An Authorisation Token as per https://tools.ietf.org/html/rfc6750"
+definitions:
+  Error:
+    type: object
+    properties:
+      ErrorCode:
+        description: >-
+          Low level textual error code.
+        type: string
+        enum:
+          - Field.Expected
+          - Field.Invalid
+          - Field.Missing
+          - Field.Unexpected
+          - Header.Invalid
+          - Header.Missing
+          - QueryParam.Invalid
+          - Reauthenticate
+          - Reauthorise
+          - Resource.Consent.CreditorAccount
+          - Resource.Consent.DebtorAccount
+          - Resource.Consent.Exceed.DataPermissions
+          - Resource.Consent.Exceed.Dates
+          - Resource.Consent.Exceed.Frequency
+          - Resource.Consent.Exceed.MaximumAmount
+          - Resource.Consent.Exceed.TotalAmount
+          - Resource.Consent.Exceed.TotalCount
+          - Resource.Consent.Exceed.TransactionDates
+          - Resource.Consent.InvalidStatus
+          - Resource.Consent.Mismatch
+          - Resource.Invalid
+          - UnexpectedError
+          - Unsupported.AccountIdentifier
+          - Unsupported.AccountSecondaryIdentifier
+          - Unsupported.Currency
+          - Unsupported.Scheme
+      Message:
+        description: >-
+          A free text description of the error that occurred. E.g.,
+          'A mandatory field isn't supplied'.
+        type: string
+        minLength: 1
+        maxLength: 500
+      Path:
+        description: >-
+          A recommended but optional reference to the JSON Path of the field
+          with error, e.g., Data.Consent.InstructedAmount.Currency
+        type: string
+        minLength: 1
+        maxLength: 500
+      Url:
+        description: >-
+          URL to help remediate the problem, provide more information or to
+          API Reference.
+        type: string
+    required:
+      - ErrorCode
+      - Message
+    additionalProperties: false
+    minProperties: 1
+  ErrorResponse:
+    description: >-
+      An array of detail error codes, and messages, and URLs to documentation to
+      help remediation.
+    type: object
+    properties:
+      Code:
+        description: >-
+          High level textual error code to help categorise the errors.
+        type: string
+        minLength: 1
+        maxLength: 128
+      Id:
+        description: >-
+          A unique reference for the error instance, for audit purposes, in
+          case of unknown/unclassified errors.
+        type: string
+        minLength: 1
+        maxLength: 128
+      Message:
+        description: >-
+          Brief Error message. E.g., 'There is something wrong with the request
+          parameters provided'
+        type: string
+        minLength: 1
+        maxLength: 500
+      Errors:
+        items:
+          $ref: "#/definitions/Error"
+        type: array
+        minItems: 1
+    required:
+      - Code
+      - Message
+      - Errors
+    additionalProperties: false
+  BalanceModel:
+    type: object
+    description: Balance object schema
+    properties:
+      AccountId:
+        description: >-
+          A unique and immutable identifier used to identify the account
+          resource. This identifier has no meaning to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      Amount:
+        description: Amount of money of the cash balance.
+        type: object
+        properties:
+          Amount:
+            type: string
+            pattern: '^\d{1,13}\.\d{1,5}$'
+          Currency:
+            description: >-
+              A code allocated to a currency by a Maintenance Agency under an
+              international identification scheme, as described in the latest
+              edition of the international standard ISO 4217 'Codes for the
+              representation of currencies and funds'
+            type: string
+            pattern: "^[A-Z]{3,3}$"
+        required:
+          - Amount
+          - Currency
+        additionalProperties: false
+      CreditDebitIndicator:
+        description: >-
+          Indicates whether the balance is a credit or a debit balance. Usage: A
+          zero balance is considered to be a credit balance.
+        type: string
+        enum:
+          - Credit
+          - Debit
+      Type:
+        description: "Balance type, in a coded form."
+        type: string
+        enum:
+          - ClosingAvailable
+          - ClosingBooked
+          - Expected
+          - ForwardAvailable
+          - Information
+          - InterimAvailable
+          - InterimBooked
+          - OpeningAvailable
+          - OpeningBooked
+          - PreviouslyClosedBooked
+      DateTime:
+        description: >-
+          Indicates the date (and time) of the balance.
+
+          All dates in the JSON payloads are represented in ISO 8601 date-time
+          format.
+
+          All date-time fields in responses must include the timezone. An
+          example is below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      CreditLine:
+        type: array
+        items:
+          type: object
+          properties:
+            Included:
+              description: >-
+                Indicates whether or not the credit line is included in the
+                balance of the account. Usage: If not present, credit line is
+                not included in the balance amount of the account.
+              type: boolean
+            Amount:
+              description: Active Or Historic Currency Code and Amount
+              type: object
+              properties:
+                Amount:
+                  type: string
+                  pattern: '^\d{1,13}\.\d{1,5}$'
+                Currency:
+                  description: >-
+                    A code allocated to a currency by a Maintenance Agency under
+                    an international identification scheme, as described in the
+                    latest edition of the international standard ISO 4217 'Codes
+                    for the representation of currencies and funds'
+                  type: string
+                  pattern: "^[A-Z]{3,3}$"
+              required:
+                - Amount
+                - Currency
+              additionalProperties: false
+            Type:
+              description: "Limit type, in a coded form."
+              type: string
+              enum:
+                - Pre-Agreed
+                - Emergency
+                - Temporary
+              additionalProperties: false
+          required:
+            - Included
+          additionalProperties: false
+    required:
+      - AccountId
+      - Amount
+      - CreditDebitIndicator
+      - DateTime
+      - Type
+    minItems: 1
+    additionalProperties: false
+  AccountModel:
+    type: object
+    properties:
+      AccountId:
+        description: >-
+          A unique and immutable identifier used to identify the account
+          resource. This identifier has no meaning to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      Currency:
+        description: >-
+          Identification of the currency in which the account is held.  Usage:
+          Currency should only be used in case one and the same account number
+          covers several currencies and the initiating party needs to identify
+          which currency needs to be used for settlement on the account.
+        type: string
+        pattern: "^[A-Z]{3,3}$"
+      AccountType:
+        description: Specifies the type of account (personal or business).
+        type: string
+        enum:
+          - Business
+          - Personal
+      AccountSubType:
+        description: Specifies the sub type of account (product family group).
+        type: string
+        enum:
+          - ChargeCard
+          - CreditCard
+          - CurrentAccount
+          - EMoney
+          - Loan
+          - Mortgage
+          - PrePaidCard
+          - Savings
+      Description:
+        description: Specifies the description of the account type.
+        type: string
+        minLength: 1
+        maxLength: 35
+      Nickname:
+        description: >-
+          The nickname of the account, assigned by the account owner in order to
+          provide an additional means of identification of the account.
+        type: string
+        minLength: 1
+        maxLength: 70
+      Account:
+        description: Provides the details to identify an account.
+        type: object
+        properties:
+          SchemeName:
+            $ref: "#/definitions/AccountSchemeModel"
+          Identification:
+            description: >-
+              Identification assigned by an institution to
+              identify an account. This identification is
+              known by the account owner.
+            type: string
+            minLength: 1
+            maxLength: 34
+          Name:
+            description: >-
+              Name of the account, as assigned by the account servicing
+              institution, in agreement with the account owner in order to
+              provide an additional means of identification of the account.
+              Usage: The account name is different from the account owner name.
+              The account name is used in certain user communities to provide a
+              means of identifying the account, in addition to the account
+              owner's identity and the account number.
+            type: string
+            minLength: 1
+            maxLength: 70
+          SecondaryIdentification:
+            description: >-
+              This is secondary identification of the account, as assigned by
+              the account servicing institution.
+            type: string
+            minLength: 1
+            maxLength: 34
+        required:
+          - SchemeName
+          - Identification
+        additionalProperties: false
+      Servicer:
+        description: >-
+          Party that manages the account on behalf of the account owner, that is
+          manages the registration and booking of entries on the account,
+          calculates balances on the account and provides information about the
+          account.
+        type: object
+        properties:
+          SchemeName:
+            description: >-
+              Name of the identification scheme, in a coded form as published in
+              an external list.
+            type: string
+            enum:
+              - BICFI
+          Identification:
+            description: >-
+              Unique and unambiguous identification of the servicing
+              institution.
+            type: string
+            minLength: 1
+            maxLength: 35
+        required:
+          - SchemeName
+          - Identification
+        additionalProperties: false
+    additionalProperties: false
+    required:
+      - AccountId
+      - Currency
+      - Nickname
+  AccountSchemeModel:
+    type: string
+    enum:
+      - BECSElectronicCredit
+      - MaskedCardNumber
+  Links:
+    title: Links
+    type: object
+    description: Links relevant to the payload
+    properties:
+      Self:
+        type: string
+        format: uri
+      First:
+        type: string
+        format: uri
+      Prev:
+        type: string
+        format: uri
+      Next:
+        type: string
+        format: uri
+      Last:
+        type: string
+        format: uri
+    required:
+      - Self
+  Risk:
+    type: object
+    description: >-
+      The Risk section is sent by the initiating party to the API Provider.
+      It is used to specify additional details for risk scoring.
+    properties:
+      GeoLocation:
+        description: >-
+          Location of the end-user on the earth specified by two numbers
+          representing vertical and horizontal position
+        type: object
+        properties:
+          Latitude:
+            description: Latitude measured in decimal degress
+            type: string
+            maxLength: 14
+            pattern: '^-?\d{1,3}\.\d{1,8}$'
+          Longitude:
+            description: Longitude measured in decimal degress
+            type: string
+            maxLength: 14
+            pattern: '^-?\d{1,3}\.\d{1,8}$'
+      PaymentContextCode:
+        description: Specifies the payment context
+        title: PaymentContextCode
+        type: string
+        enum:
+          - BillPayment
+          - EcommerceGoods
+          - EcommerceServices
+          - Other
+          - PersonToPerson
+      MerchantCategoryCode:
+        description: >-
+          Category code conforms to ISO 18245, related to the type of services
+          or goods the merchant provides for the transaction
+        type: string
+        minLength: 3
+        maxLength: 4
+      MerchantCustomerIdentification:
+        description: The unique customer identifier of the Customer with the merchant.
+        type: string
+        minLength: 1
+        maxLength: 70
+      DeliveryAddress:
+        description: >-
+          Information that locates and identifies a specific
+          address, as defined by postal services or in free format
+          text.
+        type: object
+        properties:
+          AddressType:
+            description: >-
+              Identifies the nature of the postal address.
+            type: string
+            enum:
+              - DeliveryTo
+          AddressLine:
+            description: >-
+              Information that locates and identifies a specific
+              address, as defined by postal services, that is
+              presented in free format text.
+            type: array
+            items:
+              type: string
+              minLength: 1
+              maxLength: 70
+            minItems: 0
+            maxItems: 5
+          StreetName:
+            description: >-
+              Name of a street or thoroughfare.
+            type: string
+            minLength: 1
+            maxLength: 70
+          BuildingNumber:
+            description: >-
+              Number that identifies the position of a building on a
+              street.
+            type: string
+            minLength: 1
+            maxLength: 16
+          PostCode:
+            description: >-
+              Identifier consisting of a group of letters and/or
+              numbers that is added to a postal address to assist
+              the sorting of mail
+            type: string
+            minLength: 1
+            maxLength: 16
+          TownName:
+            description: >-
+              Name of a built-up area, with defined boundaries, and
+              a local government.
+            type: string
+            minLength: 1
+            maxLength: 35
+          CountrySubDivision:
+            description: >-
+              Identifies a subdivision of a country, for instance
+              state, region, county.
+            type: string
+            minLength: 1
+            maxLength: 35
+          Country:
+            description: >-
+              Nation with its own government, occupying a particular
+              territory.
+            type: string
+            pattern: "^[A-Z]{2,2}$"
+        required:
+          - Country
+        additionalProperties: false
+      EndUserAppName:
+        description: Name of the end user facing application
+        type: string
+        minLength: 1
+        maxLength: 70
+      EndUserAppVersion:
+        description: Version of the end user facing application
+        type: string
+        minLength: 1
+        maxLength: 14
+      MerchantName:
+        description: Name of the merchant
+        type: string
+        minLength: 1
+        maxLength: 70
+      MerchantNZBN:
+        description: NZ business number for the merchant
+        type: string
+        minLength: 1
+        maxLength: 70
+    additionalProperties: false
+  AccountAccessConsentModel:
+    type: object
+    properties:
+      Consent:
+        description: >-
+          Contains the requested consent
+        type: object
+        properties:
+          Permissions:
+            description: >-
+              Specifies the Open Banking account access consent types. This is a
+              list of the data clusters being consented by the Customer, and requested
+              for authorisation with the API Provider.
+            type: array
+            items:
+              description: >-
+                Specifies the Open Banking account access consent types. This is a
+                list of the data clusters being consented by the Customer, and
+                requested for authorisation with the API Provider.
+              type: string
+              enum:
+                - ReadAccountsBasic
+                - ReadAccountsDetail
+                - ReadBalances
+                - ReadBeneficiariesBasic
+                - ReadBeneficiariesDetail
+                - ReadDirectDebits
+                - ReadOffers
+                - ReadParty
+                - ReadPartyAuthUser
+                - ReadScheduledPaymentsBasic
+                - ReadScheduledPaymentsDetail
+                - ReadStandingOrdersBasic
+                - ReadStandingOrdersDetail
+                - ReadStatementsBasic
+                - ReadStatementsDetail
+                - ReadTransactionsBasic
+                - ReadTransactionsCredits
+                - ReadTransactionsDebits
+                - ReadTransactionsDetail
+              minProperties: 1
+              additionalProperties: false
+          ExpirationDateTime:
+            description: >-
+              Specified date and time the permissions will expire. If this is not
+              populated, the permissions will be open ended.
+
+              All dates in the JSON payloads are represented in ISO 8601 date-time
+              format.
+
+              All date-time fields in responses must include the timezone. An
+              example is below:
+
+              2017-04-05T10:43:07+00:00
+            type: string
+            format: date-time
+          TransactionFromDateTime:
+            description: >-
+              Specified start date and time for the transaction query period. If
+              this is not populated, the start date will be open ended, and data
+              will be returned from the earliest available transaction.
+
+              All dates in the JSON payloads are represented in ISO 8601 date-time
+              format.
+
+              All date-time fields in responses must include the timezone. An
+              example is below:
+
+              2017-04-05T10:43:07+00:00
+            type: string
+            format: date-time
+          TransactionToDateTime:
+            description: >-
+              Specified end date and time for the transaction query period. If this
+              is not populated, the end date will be open ended, and data will be
+              returned to the latest available transaction.
+
+              All dates in the JSON payloads are represented in ISO 8601 date-time
+              format.
+
+              All date-time fields in responses must include the timezone. An
+              example is below:
+
+              2017-04-05T10:43:07+00:00
+            type: string
+            format: date-time
+        required:
+          - Permissions
+        additionalProperties: false
+    additionalProperties: false
+    required:
+      - Consent
+  AccountAccessConsentResponseModel:
+    type: object
+    allOf:
+      - properties:
+          ConsentId:
+            description: >-
+              Unique identification as assigned to identify the account access consent.
+            type: string
+            minLength: 1
+            maxLength: 128
+          Status:
+            description: Specifies the status of the account access consent.
+            type: string
+            enum:
+              - Authorised
+              - AwaitingAuthorisation
+              - Rejected
+              - Revoked
+          CreationDateTime:
+            description: >-
+              Date and time at which the consent was created.
+
+              All dates in the JSON payloads are represented in ISO 8601
+              date-time format.
+
+              All date-time fields in responses must include the timezone. An
+              example is below:
+
+              2017-04-05T10:43:07+00:00
+            type: string
+            format: date-time
+          StatusUpdateDateTime:
+            description: >-
+              Date and time at which the consent status was updated.
+
+              All dates in the JSON payloads are represented in ISO 8601 date-time
+              format.
+
+              All date-time fields in responses must include the timezone. An
+              example is below:
+
+              2017-04-05T10:43:07+00:00
+            type: string
+            format: date-time
+        required:
+          - ConsentId
+          - Status
+          - CreationDateTime
+          - StatusUpdateDateTime
+        additionalProperties: false
+      - $ref: "#/definitions/AccountAccessConsentModel"
+  TransactionModel:
+    type: object
+    properties:
+      AccountId:
+        description: >-
+          A unique and immutable identifier used to identify
+          the account resource. This identifier has no meaning
+          to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      TransactionId:
+        description: >-
+          Unique identifier for the transaction within an
+          servicing institution. This identifier is both
+          unique and immutable.
+        type: string
+        minLength: 1
+        maxLength: 40
+      TransactionReference:
+        $ref: "#/definitions/BECSRemittance"
+      StatementReference:
+        type: array
+        items:
+          description: >-
+            Unique reference for the statement. This reference may be optionally
+            populated if available.
+          type: string
+          minLength: 1
+          maxLength: 35
+        description: >-
+          Unique reference for the statement. This reference may be optionally
+          populated if available.
+      Amount:
+        description: Amount of money in the cash entry.
+        type: object
+        properties:
+          Amount:
+            type: string
+            pattern: '^\d{1,13}\.\d{1,5}$'
+          Currency:
+            description: >-
+              A code allocated to a currency by a Maintenance
+              Agency under an international identification
+              scheme, as described in the latest edition of
+              the international standard ISO 4217 'Codes for
+              the representation of currencies and funds'
+            type: string
+            pattern: "^[A-Z]{3,3}$"
+        required:
+          - Amount
+          - Currency
+        additionalProperties: false
+      CreditDebitIndicator:
+        description: >-
+          Indicates whether the transaction is a credit or a
+          debit entry.
+        type: string
+        enum:
+          - Credit
+          - Debit
+      Status:
+        description: >-
+          Status of a transaction entry on the books of the
+          account servicer.
+        type: string
+        enum:
+          - Booked
+          - Pending
+      BookingDateTime:
+        description: >-
+          Date and time when a transaction entry is posted to
+          an account on the account servicer's books. Usage:
+          Booking date is the expected booking date, unless
+          the status is booked, in which case it is the actual
+          booking date.
+
+          All dates in the JSON payloads are represented in
+          ISO 8601 date-time format.
+
+          All date-time fields in responses must include the
+          timezone. An example is below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      ValueDateTime:
+        description: >-
+          Date and time at which assets become available to
+          the account owner in case of a credit entry, or
+          cease to be available to the account owner in case
+          of a debit entry.  Usage: If entry status is pending
+          and value date is present, then the value date
+          refers to an expected/requested value date. For
+          entries subject to availability/float and for which
+          availability information is provided, the value date
+          must not be used. In this case the availability
+          component identifies the  number of availability
+          days.
+
+          All dates in the JSON payloads are represented in
+          ISO 8601 date-time format.
+
+          All date-time fields in responses must include the
+          timezone. An example is below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      AddressLine:
+        description: >-
+          Information that locates and identifies a specific
+          address, as defined by postal services, that is
+          presented in free format text.
+        type: string
+        minLength: 1
+        maxLength: 70
+      BankTransactionCode:
+        description: >-
+          Set of elements used to fully identify the type of
+          underlying transaction resulting in an entry.
+        type: object
+        properties:
+          Code:
+            description: Specifies the family within a domain.
+            type: string
+          SubCode:
+            description: >-
+              Specifies the sub-product family within a
+              specific family.
+            type: string
+        required:
+          - Code
+          - SubCode
+        additionalProperties: false
+      ProprietaryBankTransactionCode:
+        description: >-
+          Set of elements to fully identify a proprietary bank
+          transaction code.
+        type: object
+        properties:
+          Code:
+            description: >-
+              Proprietary bank transaction code to identify
+              the underlying transaction.
+            type: string
+            minLength: 1
+            maxLength: 35
+          Issuer:
+            description: >-
+              Identification of the issuer of the proprietary
+              bank transaction code.
+            type: string
+            minLength: 1
+            maxLength: 35
+        required:
+          - Code
+        additionalProperties: false
+      CurrencyExchange:
+        description: Set of elements used to provide details on the currency exchange.
+        type: object
+        properties:
+          SourceCurrency:
+            description: >-
+              Currency from which an amount is to be converted in a currency
+              conversion.
+            type: string
+            pattern: "^[A-Z]{3,3}$"
+          TargetCurrency:
+            description: >-
+              Currency from which an amount is to be converted in a currency
+              conversion.
+            type: string
+            pattern: "^[A-Z]{3,3}$"
+          UnitCurrency:
+            description: >-
+              Currency from which an amount is to be converted in a currency
+              conversion.
+            type: string
+            pattern: "^[A-Z]{3,3}$"
+          ExchangeRate:
+            description: >-
+              Factor used to convert an amount from one currency into another. This
+              reflects the price at which one currency was bought with another
+              currency.
+
+              Usage: ExchangeRate expresses the ratio between UnitCurrency and
+              QuotedCurrency (ExchangeRate = UnitCurrency/QuotedCurrency).
+            type: number
+          ContractIdentification:
+            description: >-
+              Unique identification to unambiguously identify the foreign exchange
+              contract.
+            type: string
+            minLength: 1
+            maxLength: 35
+          QuotationDate:
+            description: >-
+              Date and time at which an exchange rate is quoted.
+
+              All dates in the JSON payloads are represented in ISO 8601 date-time
+              format.
+
+              All date-time fields in responses must include the timezone. An
+              example is below:
+
+              2017-04-05T10:43:07+00:00
+            type: string
+            format: date-time
+          InstructedAmount:
+            description: >-
+              Amount of money of the cash balance after a transaction entry is applied
+              to the account..
+            type: object
+            properties:
+              Amount:
+                description: >-
+                  A number of monetary units specified in an active currency where the unit
+                  of currency is explicit and compliant with ISO 4217.
+                type: string
+                pattern: '^\d{1,13}\.\d{1,5}$'
+              Currency:
+                description: >-
+                  A code allocated to a currency by a Maintenance Agency under an
+                  international identification scheme, as described in the latest
+                  edition of the international standard ISO 4217 "Codes for the
+                  representation of currencies and funds".
+                type: string
+                pattern: "^[A-Z]{3,3}$"
+            required:
+              - Amount
+              - Currency
+            additionalProperties: false
+        required:
+          - SourceCurrency
+          - ExchangeRate
+        additionalProperties: false
+      CreditorAgent:
+        type: object
+        properties:
+          SchemeName:
+            description: >-
+              Name of the identification scheme, in a coded form as published in
+              an external list.
+            type: string
+            enum:
+              - BICFI
+          Identification:
+            type: string
+            minLength: 1
+            maxLength: 35
+            description: >-
+              Unique and unambiguous identification of a financial institution
+              or a branch of a financial institution.
+        required:
+          - SchemeName
+          - Identification
+        additionalProperties: false
+        description: Financial institution servicing an account for the creditor.
+      DebtorAgent:
+        type: object
+        properties:
+          SchemeName:
+            description: >-
+              Name of the identification scheme, in a coded form as published in
+              an external list.
+            type: string
+            enum:
+              - BICFI
+          Identification:
+            type: string
+            minLength: 1
+            maxLength: 35
+            description: >-
+              Unique and unambiguous identification of a financial institution
+              or a branch of a financial institution.
+        required:
+          - SchemeName
+          - Identification
+        additionalProperties: false
+        description: Financial institution servicing an account for the debtor.
+      CardInstrument:
+        description: >-
+          Set of elements to describe the card instrument used in the
+          transaction.
+        type: object
+        properties:
+          CardSchemeName:
+            description: Name of the card scheme.
+            type: string
+            enum:
+              - AmericanExpress
+              - Diners
+              - Discover
+              - MasterCard
+              - VISA
+          AuthorisationType:
+            description: The card authorisation type.
+            type: string
+            enum:
+              - Contactless
+              - None
+              - PIN
+          Name:
+            description: Name of the cardholder using the card instrument.
+            type: string
+            minLength: 1
+            maxLength: 70
+          Identification:
+            description: >-
+              Identification assigned by an institution to identify the card
+              instrument used in the transaction. This identification is known
+              by the account owner, and may be masked.
+            type: string
+            minLength: 1
+            maxLength: 34
+        required:
+          - CardSchemeName
+        additionalProperties: false
+      TransactionInformation:
+        description: >-
+          Further details of the transaction. This is the
+          transaction narrative, which is unstructured text.
+        type: string
+        minLength: 1
+        maxLength: 500
+      Balance:
+        description: >-
+          Set of elements used to define the balance as a
+          numerical representation of the net increases and
+          decreases in an account after a transaction entry is
+          applied to the account.
+        type: object
+        properties:
+          Amount:
+            description: >-
+              Amount of money of the cash balance after a
+              transaction entry is applied to the account..
+            type: object
+            properties:
+              Amount:
+                type: string
+                pattern: '^\d{1,13}\.\d{1,5}$'
+              Currency:
+                description: >-
+                  A code allocated to a currency by a
+                  Maintenance Agency under an international
+                  identification scheme, as described in the
+                  latest edition of the international standard
+                  ISO 4217 'Codes for the representation of
+                  currencies and funds'
+                type: string
+                pattern: "^[A-Z]{3,3}$"
+            required:
+              - Amount
+              - Currency
+            additionalProperties: false
+          CreditDebitIndicator:
+            description: >-
+              Indicates whether the balance is a credit or a
+              debit balance. Usage: A zero balance is
+              considered to be a credit balance.
+            type: string
+            enum:
+              - Credit
+              - Debit
+          Type:
+            description: "Balance type, in a coded form."
+            type: string
+            enum:
+              - ClosingAvailable
+              - ClosingBooked
+              - Expected
+              - ForwardAvailable
+              - Information
+              - InterimAvailable
+              - InterimBooked
+              - OpeningAvailable
+              - OpeningBooked
+              - PreviouslyClosedBooked
+        required:
+          - Amount
+          - CreditDebitIndicator
+          - Type
+        additionalProperties: false
+      MerchantDetails:
+        description: Details of the merchant involved in the transaction.
+        type: object
+        properties:
+          MerchantName:
+            description: Name by which the merchant is known.
+            type: string
+            minLength: 1
+            maxLength: 350
+          MerchantCategoryCode:
+            description: >-
+              Category code conform to ISO 18245, related to
+              the type of services or goods the merchant
+              provides for the transaction.
+            type: string
+            minLength: 3
+            maxLength: 4
+        additionalProperties: false
+      CreditorAccount:
+        type: object
+        properties:
+          SchemeName:
+            $ref: "#/definitions/AccountSchemeModel"
+          Identification:
+            description: >-
+              Identification assigned by an institution to
+              identify an account. This identification is
+              known by the account owner.
+            type: string
+            minLength: 1
+            maxLength: 34
+          Name:
+            type: string
+            minLength: 1
+            maxLength: 70
+            description: >-
+              Name of the account, as assigned by the account servicing
+              institution, in agreement with the account owner in order to
+              provide an additional means of identification of the account.
+
+              Usage: The account name is different from the account owner name.
+              The account name is used in certain user communities to provide a
+              means of identifying the account, in addition to the account
+              owner's identity and the account number.
+          SecondaryIdentification:
+            type: string
+            minLength: 1
+            maxLength: 34
+            description: >-
+              This is secondary identification of the account, as assigned by
+              the account servicing institution.
+        required:
+          - SchemeName
+          - Identification
+        additionalProperties: false
+        description: >-
+          Unambiguous identification of the account of the creditor, in the case
+          of a debit transaction.
+      DebtorAccount:
+        type: object
+        properties:
+          SchemeName:
+            $ref: "#/definitions/AccountSchemeModel"
+          Identification:
+            description: >-
+              Identification assigned by an institution to
+              identify an account. This identification is
+              known by the account owner.
+            type: string
+            minLength: 1
+            maxLength: 34
+          Name:
+            type: string
+            minLength: 1
+            maxLength: 70
+            description: >-
+              Name of the account, as assigned by the account servicing
+              institution, in agreement with the account owner in order to
+              provide an additional means of identification of the account.
+
+              Usage: The account name is different from the account owner name.
+              The account name is used in certain user communities to provide a
+              means of identifying the account, in addition to the account
+              owner's identity and the account number.
+          SecondaryIdentification:
+            type: string
+            minLength: 1
+            maxLength: 34
+            description: >-
+              This is secondary identification of the account, as assigned by
+              the account servicing institution.
+        required:
+          - SchemeName
+          - Identification
+        additionalProperties: false
+        description: >-
+          Unambiguous identification of the account of the debtor, in the case
+          of a crebit transaction.
+    required:
+      - AccountId
+      - Amount
+      - CreditDebitIndicator
+      - Status
+      - BookingDateTime
+    additionalProperties: false
+  BeneficiaryModel:
+    type: object
+    properties:
+      AccountId:
+        description: >-
+          A unique and immutable identifier used to identify
+          the account resource. This identifier has no meaning
+          to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      BeneficiaryId:
+        description: >-
+          A unique and immutable identifier used to identify
+          the beneficiary resource. This identifier has no
+          meaning to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      Reference:
+        $ref: "#/definitions/BECSRemittance"
+      CreditorAgent:
+        description: >-
+          Party that manages the account on behalf of the account owner, that is
+          manages the registration and booking of entries on the account,
+          calculates balances on the account and provides information about the
+          account.
+
+          This is the servicer of the beneficiary account.
+        type: object
+        properties:
+          SchemeName:
+            description: >-
+              Name of the identification scheme, in a coded form as published in
+              an external list.
+            type: string
+            enum:
+              - BICFI
+          Identification:
+            description: >-
+              Unique and unambiguous identification of the servicing
+              institution.
+            type: string
+            minLength: 1
+            maxLength: 35
+          Name:
+            description: >-
+              Name by which an agent is known and which is usually used to
+              identify that agent.
+            type: string
+            minLength: 1
+            maxLength: 140
+          PostalAddress:
+            description: >-
+              Information that locates and identifies a specific address, as
+              defined by postal services.
+            type: object
+            properties:
+              AddressType:
+                description: Identifies the nature of the postal address.
+                type: string
+                enum:
+                  - Business
+                  - Correspondence
+                  - DeliveryTo
+                  - MailTo
+                  - POBox
+                  - Postal
+                  - Residential
+                  - Statement
+              AddressLine:
+                description: >-
+                  Information that locates and identifies a specific
+                  address, as defined by postal services, that is
+                  presented in free format text.
+                type: array
+                items:
+                  type: string
+                  minLength: 1
+                  maxLength: 70
+                minItems: 0
+                maxItems: 5
+              StreetName:
+                description: Name of a street or thoroughfare.
+                type: string
+                minLength: 1
+                maxLength: 70
+              BuildingNumber:
+                description: >-
+                  Number that identifies the position of a building on a street.
+                type: string
+                minLength: 1
+                maxLength: 16
+              PostCode:
+                description: >-
+                  Identifier consisting of a group of letters and/or numbers
+                  that is added to a postal address to assist the sorting of
+                  mail.
+                type: string
+                minLength: 1
+                maxLength: 16
+              TownName:
+                description: >-
+                  Name of a built-up area, with defined boundaries, and a local
+                  government.
+                type: string
+                minLength: 1
+                maxLength: 35
+              CountrySubDivision:
+                description: >-
+                  Identifies a subdivision of a country such as state, region,
+                  county.
+                type: string
+                minLength: 1
+                maxLength: 35
+              Country:
+                description: Nation with its own government.
+                type: string
+                pattern: "^[A-Z]{2,2}$"
+            required:
+              - Country
+            additionalProperties: false
+        additionalProperties: false
+      CreditorAccount:
+        description: >-
+          Provides the details to identify the beneficiary
+          account.
+        type: object
+        properties:
+          SchemeName:
+            $ref: "#/definitions/AccountSchemeModel"
+          Identification:
+            description: >-
+              Identification assigned by an institution to
+              identify an account. This identification is
+              known by the account owner.
+            type: string
+            minLength: 1
+            maxLength: 34
+          Name:
+            description: >-
+              Name of the account, as assigned by the account
+              servicing institution, in agreement with the
+              account owner in order to provide an additional
+              means of identification of the account. Usage:
+              The account name is different from the account
+              owner name. The account name is used in certain
+              user communities to provide a means of
+              identifying the account, in addition to the
+              account owner's identity and the account number.
+            type: string
+            minLength: 1
+            maxLength: 70
+          SecondaryIdentification:
+            description: >-
+              This is secondary identification of the account, as assigned by the
+              account servicing institution.
+            type: string
+            minLength: 1
+            maxLength: 34
+        required:
+          - SchemeName
+          - Identification
+        additionalProperties: false
+    required:
+      - AccountId
+    additionalProperties: false
+  StandingOrderModel:
+    type: object
+    properties:
+      AccountId:
+        description: >-
+          A unique and immutable identifier used to identify
+          the account resource. This identifier has no meaning
+          to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      StandingOrderId:
+        description: >-
+          A unique and immutable identifier used to identify
+          the standing order resource. This identifier has no
+          meaning to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      Frequency:
+        description: >
+          EvryDay - Every day
+
+          EvryWorkgDay - Every working day
+
+          IntrvlWkDay - An interval specified in weeks (01 to
+          09), and the day within the week (01 to 07)
+
+          WkInMnthDay - A monthly interval, specifying the
+          week of the month (01 to 05) and day within the week
+          (01 to 07)
+
+          IntrvlMnthDay - An interval specified in months
+          (between 01 to 06, 12, 24), specifying the day
+          within the month (-5 to -1, 1 to 31)
+
+
+          Patterns:
+
+          EvryDay (ScheduleCode)
+
+          EvryWorkgDay (ScheduleCode)
+
+          IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode
+          + IntervalInWeeks + DayInWeek)
+
+          WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode +
+          WeekInMonth + DayInWeek)
+
+          IntrvlMnthDay:IntervalInMonths:DayInMonth
+          (ScheduleCode + IntervalInMonths + DayInMonth)
+
+
+          The regular expression for this element combines
+          five smaller versions for each permitted pattern. To
+          aid legibility - the components are presented
+          individually here:
+
+          EvryDay
+
+          EvryWorkgDay
+
+          IntrvlWkDay:0[1-9]:0[1-7]
+
+          WkInMnthDay:0[1-5]:0[1-7]
+
+          IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01])
+
+        type: string
+        pattern: >-
+          ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$
+      Reference:
+        $ref: "#/definitions/BECSRemittance"
+      FirstPaymentDateTime:
+        description: >-
+          The date on which the first payment for a Standing
+          Order schedule will be made.
+
+          All dates in the JSON payloads are represented in
+          ISO 8601 date-time format.
+
+          All date-time fields in responses must include the
+          timezone. An example is below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      FirstPaymentAmount:
+        description: The amount of the first Standing Order
+        type: object
+        properties:
+          Amount:
+            type: string
+            pattern: '^\d{1,13}\.\d{1,5}$'
+          Currency:
+            description: >-
+              A code allocated to a currency by a Maintenance
+              Agency under an international identification
+              scheme, as described in the latest edition of
+              the international standard ISO 4217 'Codes for
+              the representation of currencies and funds'
+            type: string
+            pattern: "^[A-Z]{3,3}$"
+        required:
+          - Amount
+          - Currency
+        additionalProperties: false
+      NextPaymentDateTime:
+        description: >-
+          The date on which the next payment for a Standing
+          Order schedule will be made.
+
+          All dates in the JSON payloads are represented in
+          ISO 8601 date-time format.
+
+          All date-time fields in responses must include the
+          timezone. An example is below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      NextPaymentAmount:
+        description: The amount of the next Standing Order
+        type: object
+        properties:
+          Amount:
+            type: string
+            pattern: '^\d{1,13}\.\d{1,5}$'
+          Currency:
+            description: >-
+              A code allocated to a currency by a Maintenance
+              Agency under an international identification
+              scheme, as described in the latest edition of
+              the international standard ISO 4217 'Codes for
+              the representation of currencies and funds'
+            type: string
+            pattern: "^[A-Z]{3,3}$"
+        required:
+          - Amount
+          - Currency
+        additionalProperties: false
+      FinalPaymentDateTime:
+        description: >-
+          The date on which the final payment for a Standing
+          Order schedule will be made.
+
+          All dates in the JSON payloads are represented in
+          ISO 8601 date-time format.
+
+          All date-time fields in responses must include the
+          timezone. An example is below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      FinalPaymentAmount:
+        description: The amount of the final Standing Order
+        type: object
+        properties:
+          Amount:
+            type: string
+            pattern: '^\d{1,13}\.\d{1,5}$'
+          Currency:
+            description: >-
+              A code allocated to a currency by a Maintenance
+              Agency under an international identification
+              scheme, as described in the latest edition of
+              the international standard ISO 4217 'Codes for
+              the representation of currencies and funds'
+            type: string
+            pattern: "^[A-Z]{3,3}$"
+        required:
+          - Amount
+          - Currency
+        additionalProperties: false
+      StandingOrderStatusCode:
+        description: Specifies the status of the standing order in code form.
+        type: string
+        enum:
+          - Active
+          - Inactive
+      CreditorAgent:
+        description: >-
+          Party that manages the account on behalf of the
+          account owner, that is manages the registration and
+          booking of entries on the account, calculates
+          balances on the account and provides information
+          about the account. This is the servicer of the
+          beneficiary account
+        type: object
+        properties:
+          SchemeName:
+            description: >-
+              Name of the identification scheme, in a coded
+              form as published in an external list.
+            type: string
+            enum:
+              - BICFI
+          Identification:
+            description: >-
+              Unique and unambiguous identification of the
+              servicing institution.
+            type: string
+            minLength: 1
+            maxLength: 35
+        required:
+          - SchemeName
+          - Identification
+        additionalProperties: false
+      CreditorAccount:
+        description: >-
+          Provides the details to identify the beneficiary
+          account.
+        type: object
+        properties:
+          SchemeName:
+            $ref: "#/definitions/AccountSchemeModel"
+          Identification:
+            description: >-
+              Identification assigned by an institution to
+              identify an account. This identification is
+              known by the account owner.
+            type: string
+            minLength: 1
+            maxLength: 34
+          Name:
+            description: >-
+              Name of the account, as assigned by the account
+              servicing institution, in agreement with the
+              account owner in order to provide an additional
+              means of identification of the account. Usage:
+              The account name is different from the account
+              owner name. The account name is used in certain
+              user communities to provide a means of
+              identifying the account, in addition to the
+              account owner's identity and the account number.
+            type: string
+            minLength: 1
+            maxLength: 70
+          SecondaryIdentification:
+            description: >-
+              This is secondary identification of the account,
+              as assigned by the account servicing institution.
+            type: string
+            minLength: 1
+            maxLength: 34
+        required:
+          - SchemeName
+          - Identification
+        additionalProperties: false
+    required:
+      - AccountId
+      - Frequency
+      - NextPaymentDateTime
+      - NextPaymentAmount
+    additionalProperties: false
+  DirectDebitModel:
+    type: object
+    properties:
+      AccountId:
+        description: >-
+          A unique and immutable identifier used to identify
+          the account resource. This identifier has no meaning
+          to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      DirectDebitId:
+        description: >-
+          A unique and immutable identifier used to identify
+          the direct debit resource. This identifier has no
+          meaning to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      MandateIdentification:
+        description: >-
+          Direct Debit reference.
+        type: string
+        minLength: 1
+        maxLength: 35
+      DirectDebitStatusCode:
+        description: >-
+          Specifies the status of the direct debit in code
+          form.
+        type: string
+        enum:
+          - Active
+          - Inactive
+      Name:
+        description: Name of Service User
+        type: string
+        minLength: 1
+        maxLength: 70
+      PreviousPaymentDateTime:
+        description: >-
+          Date of most recent direct debit collection.
+
+          All dates in the JSON payloads are represented in
+          ISO 8601 date-time format.
+
+          All date-time fields in responses must include the
+          timezone. An example is below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      PreviousPaymentAmount:
+        description: >-
+          The amount of the most recent direct debit
+          collection.
+        type: object
+        properties:
+          Amount:
+            type: string
+            pattern: '^\d{1,13}\.\d{1,5}$'
+          Currency:
+            description: >-
+              A code allocated to a currency by a Maintenance
+              Agency under an international identification
+              scheme, as described in the latest edition of
+              the international standard ISO 4217 'Codes for
+              the representation of currencies and funds'
+            type: string
+            pattern: "^[A-Z]{3,3}$"
+        required:
+          - Amount
+          - Currency
+        additionalProperties: false
+    required:
+      - AccountId
+      - MandateIdentification
+      - Name
+    additionalProperties: false
+  OfferModel:
+    type: object
+    properties:
+      AccountId:
+        description: >-
+          A unique and immutable identifier used to identify
+          the account resource. This identifier has no meaning
+          to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      OfferId:
+        description: >-
+          A unique and immutable identifier used to identify the offer resource.
+          This identifier has no meaning to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      OfferType:
+        description: "Offer type, in a coded form."
+        type: string
+        enum:
+          - BalanceTransfer
+          - LimitIncrease
+          - MoneyTransfer
+          - Other
+          - PromotionalRate
+      Description:
+        description: Further details of the offer.
+        type: string
+        minLength: 1
+        maxLength: 500
+      StartDateTime:
+        description: >-
+          Date and time at which the offer starts.
+
+          All dates in the JSON payloads are represented in ISO 8601 date-time
+          format.
+
+          All date-time fields in responses must include the timezone. An
+          example is below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      EndDateTime:
+        description: >-
+          Date and time at which the offer ends.
+
+          All dates in the JSON payloads are represented in ISO 8601 date-time
+          format.
+
+          All date-time fields in responses must include the timezone. An
+          example is below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      Amount:
+        description: Amount of money associated with the offer type.
+        type: object
+        properties:
+          Amount:
+            type: string
+            pattern: '^\d{1,13}\.\d{1,5}$'
+          Currency:
+            description: >-
+              A code allocated to a currency by a Maintenance Agency under an
+              international identification scheme, as described in the latest
+              edition of the international standard ISO 4217 "Codes for the
+              representation of currencies and funds".
+            type: string
+            pattern: "^[A-Z]{3,3}$"
+        required:
+          - Amount
+          - Currency
+        additionalProperties: false
+      Fee:
+        description: Fee associated with the offer type.
+        type: object
+        properties:
+          Amount:
+            type: string
+            pattern: '^\d{1,13}\.\d{1,5}$'
+          Currency:
+            description: >-
+              A code allocated to a currency by a Maintenance Agency under an
+              international identification scheme, as described in the latest
+              edition of the international standard ISO 4217 "Codes for the
+              representation of currencies and funds".
+            type: string
+            pattern: "^[A-Z]{3,3}$"
+        required:
+          - Amount
+          - Currency
+        additionalProperties: false
+      Rate:
+        description: Rate associated with the offer type.
+        type: string
+        minLength: 1
+        maxLength: 10
+        pattern: '^(-?\d{1,3}){1}(\.\d{1,4}){0,1}$'
+      Value:
+        description: Value associated with the offer type.
+        type: integer
+        format: int32
+      Term:
+        description: Further details of the term of the offer.
+        type: string
+        minLength: 1
+        maxLength: 500
+      URL:
+        description: URL (Uniform Resource Locator) where the document can be found
+        type: string
+        minLength: 1
+        maxLength: 256
+    required:
+      - AccountId
+    additionalProperties: false
+  PartyModel:
+    type: object
+    properties:
+      PartyId:
+        description: >-
+          A unique and immutable identifier used to identify the customer
+          resource. This identifier has no meaning to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      PartyNumber:
+        description: Number assigned by an agent to identify its customer.
+        type: string
+        minLength: 1
+        maxLength: 35
+      PartyType:
+        description: "Party type, in a coded form."
+        type: string
+        enum:
+          - Delegate
+          - Joint
+          - Sole
+      Name:
+        description: >-
+          Name by which a party is known and which is usually used to identify
+          that party.
+        type: string
+        minLength: 1
+        maxLength: 70
+      EmailAddress:
+        description: Address for electronic mail (e-mail).
+        type: string
+        minLength: 1
+        maxLength: 256
+      Phone:
+        description: >-
+          Collection of information that identifies a phone number, as defined
+          by telecom services.
+        type: string
+        pattern: '\+[0-9]{1,3}-[0-9()+\-]{1,30}'
+      Mobile:
+        description: >-
+          Collection of information that identifies a mobile phone number, as
+          defined by telecom services.
+        type: string
+        pattern: '\+[0-9]{1,3}-[0-9()+\-]{1,30}'
+      Address:
+        type: array
+        description: Postal address of a party.
+        items:
+          description: Postal address of a party.
+          type: object
+          properties:
+            AddressType:
+              description: Identifies the nature of the postal address.
+              type: string
+              enum:
+                - Business
+                - Correspondence
+                - DeliveryTo
+                - MailTo
+                - POBox
+                - Postal
+                - Residential
+                - Statement
+            AddressLine:
+              description: >-
+                Information that locates and identifies a specific
+                address, as defined by postal services, that is
+                presented in free format text.
+              type: array
+              items:
+                type: string
+                minLength: 1
+                maxLength: 70
+              minItems: 0
+              maxItems: 5
+            StreetName:
+              description: >-
+                Name of a street or thoroughfare.
+              type: string
+              minLength: 1
+              maxLength: 70
+            BuildingNumber:
+              description: >-
+                Number that identifies the position of a building on a street.
+              type: string
+              minLength: 1
+              maxLength: 16
+            PostCode:
+              description: >-
+                Identifier consisting of a group of letters and/or numbers that is
+                added to a postal address to assist the sorting of mail.
+              type: string
+              minLength: 1
+              maxLength: 16
+            TownName:
+              description: >-
+                Name of a built-up area, with defined boundaries, and a local
+                government.
+              type: string
+              minLength: 1
+              maxLength: 35
+            CountrySubDivision:
+              description: >-
+                Identifies a subdivision of a country eg, state, region, county.
+              type: string
+              minLength: 1
+              maxLength: 35
+            Country:
+              description: >-
+                Nation with its own government, occupying a particular territory.
+              type: string
+              pattern: "^[A-Z]{2,2}$"
+          required:
+            - Country
+          additionalProperties: false
+    required:
+      - PartyId
+    additionalProperties: false
+  ScheduledPaymentModel:
+    type: object
+    properties:
+      AccountId:
+        description: >-
+          A unique and immutable identifier used to identify the account
+          resource. This identifier has no meaning to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      ScheduledPaymentId:
+        description: >-
+          A unique and immutable identifier used to identify the scheduled
+          payment resource. This identifier has no meaning to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      ScheduledPaymentDateTime:
+        description: >-
+          The date on which the scheduled payment will be made.
+
+          All dates in the JSON payloads are represented in ISO 8601 date-time
+          format.
+
+          All date-time fields in responses must include the timezone. An
+          example is below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      ScheduledType:
+        description: Specifies the scheduled payment date type requested
+        type: string
+        enum:
+          - Arrival
+          - Execution
+      InstructedAmount:
+        description: >-
+          Amount of money to be moved between the debtor and creditor, before
+          deduction of charges, expressed in the currency as ordered by the
+          initiating party.
+
+          Usage: This amount has to be transported unchanged through the
+          transaction chain.
+        type: object
+        properties:
+          Amount:
+            type: string
+            pattern: '^\d{1,13}\.\d{1,5}$'
+          Currency:
+            description: >-
+              A code allocated to a currency by a Maintenance Agency under an
+              international identification scheme, as described in the latest
+              edition of the international standard ISO 4217 "Codes for the
+              representation of currencies and funds".
+            type: string
+            pattern: "^[A-Z]{3,3}$"
+        required:
+          - Amount
+          - Currency
+        additionalProperties: false
+      Reference:
+        $ref: "#/definitions/BECSRemittance"
+      CreditorAgent:
+        type: object
+        properties:
+          SchemeName:
+            description: >-
+              Name of the identification scheme, in a coded form as published in
+              an external list.
+            type: string
+            enum:
+              - BICFI
+          Identification:
+            type: string
+            minLength: 1
+            maxLength: 35
+            description: >-
+              Unique and unambiguous identification of a financial institution
+              or a branch of a financial institution.
+        required:
+          - SchemeName
+          - Identification
+        additionalProperties: false
+        description: Financial institution servicing an account for the creditor.
+      CreditorAccount:
+        type: object
+        properties:
+          SchemeName:
+            $ref: "#/definitions/AccountSchemeModel"
+          Identification:
+            description: >-
+              Identification assigned by an institution to
+              identify an account. This identification is
+              known by the account owner.
+            type: string
+            minLength: 1
+            maxLength: 34
+          Name:
+            type: string
+            minLength: 1
+            maxLength: 70
+            description: >-
+              Name of the account, as assigned by the account servicing
+              institution, in agreement with the account owner in order to
+              provide an additional means of identification of the account.
+
+              Usage: The account name is different from the account owner name.
+              The account name is used in certain user communities to provide a
+              means of identifying the account, in addition to the account
+              owner's identity and the account number.
+          SecondaryIdentification:
+            type: string
+            minLength: 1
+            maxLength: 34
+            description: >-
+              This is secondary identification of the account, as assigned by
+              the account servicing institution.
+        required:
+          - SchemeName
+          - Identification
+        additionalProperties: false
+        description: Provides the details to identify the beneficiary account.
+    required:
+      - AccountId
+      - ScheduledPaymentDateTime
+      - ScheduledType
+      - InstructedAmount
+    additionalProperties: false
+  StatementModel:
+    description: Provides further details on a statement resource.
+    type: object
+    properties:
+      AccountId:
+        description: >-
+          A unique and immutable identifier used to identify the account
+          resource. This identifier has no meaning to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      StatementId:
+        description: >-
+          Unique identifier for the statement resource within an servicing
+          institution. This identifier is both unique and immutable.
+        type: string
+        minLength: 1
+        maxLength: 40
+      StatementReference:
+        description: >-
+          Unique reference for the statement. This reference may be optionally
+          populated if available.
+        type: string
+        minLength: 1
+        maxLength: 35
+      Type:
+        description: "Statement type, in a coded form."
+        type: string
+        enum:
+          - AccountClosure
+          - AccountOpening
+          - Annual
+          - Interim
+          - RegularPeriodic
+      StartDateTime:
+        description: >-
+          Date and time at which the statement period starts.
+
+          All dates in the JSON payloads are represented in ISO 8601 date-time
+          format.
+
+          All date-time fields in responses must include the timezone. An
+          example is below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      EndDateTime:
+        description: >-
+          Date and time at which the statement period ends.
+
+          All dates in the JSON payloads are represented in ISO 8601 date-time
+          format.
+
+          All date-time fields in responses must include the timezone. An
+          example is below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      CreationDateTime:
+        description: >-
+          Date and time at which the resource was created.
+
+          All dates in the JSON payloads are represented in ISO 8601 date-time
+          format.
+
+          All date-time fields in responses must include the timezone. An
+          example is below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      StatementDescription:
+        items:
+          description: >-
+            Other descriptions that may be available for the statement resource.
+          type: string
+          minLength: 1
+          maxLength: 500
+        type: array
+        description: >-
+          Other descriptions that may be available for the statement resource.
+      StatementBenefit:
+        type: array
+        description: >-
+          Set of elements used to provide details of a benefit or reward amount
+          for the statement resource.
+        items:
+          description: >-
+            Set of elements used to provide details of a benefit or reward
+            amount for the statement resource.
+          type: object
+          properties:
+            Amount:
+              description: Amount of money associated with the statement benefit type.
+              type: object
+              properties:
+                Amount:
+                  type: string
+                  pattern: '^\d{1,13}\.\d{1,5}$'
+                Currency:
+                  description: >-
+                    A code allocated to a currency by a Maintenance Agency under
+                    an international identification scheme, as described in the
+                    latest edition of the international standard ISO 4217 "Codes
+                    for the representation of currencies and funds".
+                  type: string
+                  pattern: "^[A-Z]{3,3}$"
+              required:
+                - Amount
+                - Currency
+              additionalProperties: false
+            Type:
+              description: "Benefit type, in a coded form."
+              type: string
+              enum:
+                - Cashback
+                - Insurance
+                - TravelDiscount
+                - TravelInsurance
+          required:
+            - Amount
+            - Type
+          additionalProperties: false
+      StatementFee:
+        type: array
+        description: >-
+          Set of elements used to provide details of a fee for the statement
+          resource.
+        items:
+          description: >-
+            Set of elements used to provide details of a fee for the statement
+            resource.
+          type: object
+          properties:
+            Amount:
+              description: Amount of money associated with the statement fee type.
+              type: object
+              properties:
+                Amount:
+                  type: string
+                  pattern: '^\d{1,13}\.\d{1,5}$'
+                Currency:
+                  description: >-
+                    A code allocated to a currency by a Maintenance Agency under
+                    an international identification scheme, as described in the
+                    latest edition of the international standard ISO 4217 "Codes
+                    for the representation of currencies and funds".
+                  type: string
+                  pattern: "^[A-Z]{3,3}$"
+              required:
+                - Amount
+                - Currency
+              additionalProperties: false
+            CreditDebitIndicator:
+              type: string
+              enum:
+                - Credit
+                - Debit
+              description: >-
+                Indicates whether the amount is a credit or a debit.
+                Usage: A zero amount is considered to be a credit amount.
+            Type:
+              description: "Fee type, in a coded form."
+              type: string
+              enum:
+                - Annual
+                - BalanceTransfer
+                - CashAdvance
+                - CashTransaction
+                - ForeignTransaction
+                - Gambling
+                - LatePayment
+                - MoneyTransfer
+                - Monthly
+                - Overlimit
+                - PostalOrder
+                - PrizeEntry
+                - StatementCopy
+                - Total
+          required:
+            - Amount
+            - CreditDebitIndicator
+            - Type
+          additionalProperties: false
+      StatementInterest:
+        type: array
+        description: >-
+          Set of elements used to provide details of a generic interest amount
+          related to the statement resource.
+        items:
+          description: >-
+            Set of elements used to provide details of a generic interest amount
+            related to the statement resource.
+          type: object
+          properties:
+            Amount:
+              description: >-
+                Amount of money associated with the statement interest amount
+                type.
+              type: object
+              properties:
+                Amount:
+                  type: string
+                  pattern: '^\d{1,13}\.\d{1,5}$'
+                Currency:
+                  description: >-
+                    A code allocated to a currency by a Maintenance Agency under
+                    an international identification scheme, as described in the
+                    latest edition of the international standard ISO 4217 "Codes
+                    for the representation of currencies and funds".
+                  type: string
+                  pattern: "^[A-Z]{3,3}$"
+              required:
+                - Amount
+                - Currency
+              additionalProperties: false
+            CreditDebitIndicator:
+              type: string
+              enum:
+                - Credit
+                - Debit
+              description: >-
+                Indicates whether the amount is a credit or a debit.
+                Usage: A zero amount is considered to be a credit amount.
+            Type:
+              description: "Interest amount type, in a coded form."
+              type: string
+              enum:
+                - BalanceTransfer
+                - Cash
+                - EstimatedNext
+                - Purchase
+                - Total
+          required:
+            - Amount
+            - CreditDebitIndicator
+            - Type
+          additionalProperties: false
+      StatementDateTime:
+        type: array
+        description: >-
+          Set of elements used to provide details of a generic date time for the
+          statement resource.
+        items:
+          description: >-
+            Set of elements used to provide details of a generic date time for
+            the statement resource.
+          type: object
+          properties:
+            DateTime:
+              description: >-
+                Date and time associated with the date time type.
+
+                All dates in the JSON payloads are represented in ISO 8601
+                date-time format.
+
+                All date-time fields in responses must include the timezone. An
+                example is below:
+
+                2017-04-05T10:43:07+00:00
+              type: string
+              format: date-time
+            Type:
+              description: "Date time type, in a coded form."
+              type: string
+              enum:
+                - BalanceTransferPromoEnd
+                - DirectDebitDue
+                - LastPayment
+                - LastStatement
+                - NextStatement
+                - PaymentDue
+                - PurchasePromoEnd
+                - StatementAvailable
+          required:
+            - DateTime
+            - Type
+          additionalProperties: false
+      StatementRate:
+        type: array
+        description: >-
+          Set of elements used to provide details of a generic rate related to
+          the statement resource.
+        items:
+          description: >-
+            Set of elements used to provide details of a generic rate related to
+            the statement resource.
+          type: object
+          properties:
+            Rate:
+              description: Rate associated with the statement rate type.
+              type: string
+              minLength: 1
+              maxLength: 10
+              pattern: '^(-?\d{1,3}){1}(\.\d{1,4}){0,1}$'
+            Type:
+              description: "Statement rate type, in a coded form."
+              type: string
+              enum:
+                - AnnualBalanceTransfer
+                - AnnualBalanceTransferAfterPromo
+                - AnnualBalanceTransferPromo
+                - AnnualCash
+                - AnnualPurchase
+                - AnnualPurchaseAfterPromo
+                - AnnualPurchasePromo
+                - MonthlyBalanceTransfer
+                - MonthlyCash
+                - MonthlyPurchase
+          required:
+            - Rate
+            - Type
+          additionalProperties: false
+      StatementValue:
+        type: array
+        description: >-
+          Set of elements used to provide details of a generic number value
+          related to the statement resource.
+        items:
+          description: >-
+            Set of elements used to provide details of a generic number value
+            related to the statement resource.
+          type: object
+          properties:
+            Value:
+              description: Value associated with the statement value type.
+              type: integer
+              format: int32
+            Type:
+              description: "Statement value type, in a coded form."
+              type: string
+              enum:
+                - AirMilesPoints
+                - AirMilesPointsBalance
+                - Credits
+                - Debits
+                - HotelPoints
+                - HotelPointsBalance
+                - RetailShoppingPoints
+                - RetailShoppingPointsBalance
+          required:
+            - Value
+            - Type
+          additionalProperties: false
+      StatementAmount:
+        type: array
+        description: >-
+          Set of elements used to provide details of a generic amount for the
+          statement resource.
+        items:
+          description: >-
+            Set of elements used to provide details of a generic amount for the
+            statement resource.
+          type: object
+          properties:
+            Amount:
+              description: Amount of money associated with the amount type.
+              type: object
+              properties:
+                Amount:
+                  type: string
+                  pattern: '^\d{1,13}\.\d{1,5}$'
+                Currency:
+                  description: >-
+                    A code allocated to a currency by a Maintenance Agency under
+                    an international identification scheme, as described in the
+                    latest edition of the international standard ISO 4217 "Codes
+                    for the representation of currencies and funds".
+                  type: string
+                  pattern: "^[A-Z]{3,3}$"
+              required:
+                - Amount
+                - Currency
+              additionalProperties: false
+            CreditDebitIndicator:
+              type: string
+              enum:
+                - Credit
+                - Debit
+              description: >-
+                Indicates whether the amount is a credit or a debit.
+                Usage: A zero amount is considered to be a credit amount.
+            Type:
+              description: "Amount type, in a coded form."
+              type: string
+              enum:
+                - ArrearsClosingBalance
+                - AvailableBalance
+                - AverageBalanceWhenInCredit
+                - AverageBalanceWhenInDebit
+                - AverageDailyBalance
+                - BalanceTransferClosingBalance
+                - CashClosingBalance
+                - ClosingBalance
+                - CreditLimit
+                - CurrentPayment
+                - DirectDebitPaymentDue
+                - MinimumPaymentDue
+                - PreviousClosingBalance
+                - PreviousPayment
+                - PurchaseClosingBalance
+                - StartingBalance
+                - TotalAdjustments
+                - TotalCashAdvances
+                - TotalCharges
+                - TotalCredits
+                - TotalDebits
+                - TotalPurchases
+          required:
+            - Amount
+            - CreditDebitIndicator
+            - Type
+          additionalProperties: false
+    required:
+      - AccountId
+      - Type
+      - StartDateTime
+      - EndDateTime
+      - CreationDateTime
+    additionalProperties: false
+  BECSRemittance:
+    type: object
+    description: >-
+      Unique reference, as assigned by the creditor, to
+      unambiguously refer to the payment transaction.
+      Usage: If available, the initiating party should
+      provide this reference in the structured remittance
+      information, to enable reconciliation by the
+      creditor upon receipt of the amount of money. If the
+      business context requires the use of a creditor
+      reference or a payment remit identification, and
+      only one identifier can be passed through the
+      end-to-end chain, the creditor's reference or
+      payment remittance identification should be quoted
+      in the end-to-end transaction identification.
+
+      NZ - Remittance information for use with BECS Electronic Credit payment scheme.
+      The Particulars, Code and Reference fields are currently constrained by
+      providers.  The design choice has been made not to constrain through schema
+      restrictions, to allow for future changes that remove the constraint.
+      Note that not all banks will accept all valid characters, in which case a
+      descriptive 400 Bad Request will be returned. Constraining to a-z, A-Z, -
+      (dash) and 0-9 is advised. One example is abc-XYZ-123
+    properties:
+      CreditorName:
+        type: string
+        maxLength: 20
+      CreditorReference:
+        type: object
+        properties:
+          Particulars:
+            type: string
+            maxLength: 12
+          Code:
+            type: string
+            maxLength: 12
+          Reference:
+            type: string
+            maxLength: 12
+        additionalProperties: false
+      DebtorName:
+        type: string
+        maxLength: 20
+      DebtorReference:
+        type: object
+        properties:
+          Particulars:
+            type: string
+            maxLength: 12
+          Code:
+            type: string
+            maxLength: 12
+          Reference:
+            type: string
+            maxLength: 12
+        additionalProperties: false
+    required:
+      - CreditorName
+    additionalProperties: false
+  Meta:
+    title: MetaData
+    type: object
+    description: Meta Data relevant to the payload
+    properties:
+      TotalPages:
+        type: integer
+        format: int32
+      FirstAvailableDateTime:
+        description: >-
+          All dates in the JSON payloads are represented in ISO 8601 date-time
+          format.
+
+          All date-time fields in responses must include the timezone. An example is
+          below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      LastAvailableDateTime:
+        description: >-
+          All dates in the JSON payloads are represented in ISO 8601 date-time
+          format.
+
+          All date-time fields in responses must include the timezone. An example is
+          below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+    additionalProperties: false
+securityDefinitions:
+  CustomerOAuth2Security:
+    type: oauth2
+    flow: accessCode
+    tokenUrl: "https://authserver.example/token"
+    authorizationUrl: "https://authserver.example/authorization"
+    scopes:
+      accounts: Ability to read accounts information
+    description: >-
+      OAuth flow, it is required when the Customer needs to perform SCA with the
+      API Provider when a Third Party wants to access an API Provider resource owned
+      by the Customer
+  ThirdPartyOAuth2Security:
+    type: oauth2
+    flow: application
+    tokenUrl: "https://authserver.example/token"
+    scopes:
+      accounts: Ability to read accounts information
+    description: >-
+      Third Party client credential authorisation flow with the API Provider
+responses:
+  400ErrorResponse:
+    description: Bad Request
+    headers:
+      x-fapi-interaction-id:
+        type: string
+        description: An RFC4122 UID used as a correlation id.
+    schema:
+      $ref: "#/definitions/ErrorResponse"
+  401ErrorResponse:
+    description: Unauthorized
+    headers:
+      x-fapi-interaction-id:
+        type: string
+        description: An RFC4122 UID used as a correlation id.
+  403ErrorResponse:
+    description: Forbidden
+    headers:
+      x-fapi-interaction-id:
+        type: string
+        description: An RFC4122 UID used as a correlation id.
+    schema:
+      $ref: "#/definitions/ErrorResponse"
+  405ErrorResponse:
+    description: Method Not Allowed
+    headers:
+      x-fapi-interaction-id:
+        type: string
+        description: An RFC4122 UID used as a correlation id.
+  406ErrorResponse:
+    description: Not Acceptable
+    headers:
+      x-fapi-interaction-id:
+        type: string
+        description: An RFC4122 UID used as a correlation id.
+  415ErrorResponse:
+    description: Unsupported Media Type
+    headers:
+      x-fapi-interaction-id:
+        type: string
+        description: An RFC4122 UID used as a correlation id.
+  429ErrorResponse:
+    description: Too Many Requests
+    headers:
+      Retry-After:
+        description: Number in seconds to wait
+        type: integer
+      x-fapi-interaction-id:
+        type: string
+        description: An RFC4122 UID used as a correlation id.
+  500ErrorResponse:
+    description: Internal Server Error
+    headers:
+      x-fapi-interaction-id:
+        type: string
+        description: An RFC4122 UID used as a correlation id.
+    schema:
+      $ref: "#/definitions/ErrorResponse"
+  501ErrorResponse:
+    description: Not Implemented
+    headers:
+      x-fapi-interaction-id:
+        type: string
+        description: An RFC4122 UID used as a correlation id.
+  503ErrorResponse:
+    description: Service Unavailable
+    headers:
+      x-fapi-interaction-id:
+        type: string
+        description: An RFC4122 UID used as a correlation id.
+    schema:
+      $ref: "#/definitions/ErrorResponse"

--- a/dist/v2.2.2/Readme.md
+++ b/dist/v2.2.2/Readme.md
@@ -1,7 +1,7 @@
 # Account Information API
 
-## V2.2.1
+## V2.2.2
 
-This is v2.2.1 NZ Open Banking Account Information API technical specification.
+This is v2.2.2 NZ Open Banking Account Information API technical specification.
 
 The Swagger 2.0 document is [here](account-info-nz-swagger.yaml).

--- a/dist/v2.2.2/Readme.md
+++ b/dist/v2.2.2/Readme.md
@@ -1,0 +1,7 @@
+# Account Information API
+
+## V2.2.1
+
+This is v2.2.1 NZ Open Banking Account Information API technical specification.
+
+The Swagger 2.0 document is [here](account-info-nz-swagger.yaml).

--- a/dist/v2.2.2/account-info-nz-swagger.yaml
+++ b/dist/v2.2.2/account-info-nz-swagger.yaml
@@ -1,0 +1,4448 @@
+swagger: "2.0"
+info:
+  title: Account and Transaction API Specification
+  description: >-
+    Swagger for Account and Transaction API Specification. This is heavily
+    derived from the Open Banking UK API - see www.openbanking.org.uk for
+    details.
+  termsOfService: "https://www.apicentre.paymentsnz.co.nz/contact-us/"
+  contact:
+    name: Payments NZ API Centre
+    email: apicentre@paymentsnz.co.nz
+  license:
+    name: Licence
+    url: "https://www.apicentre.paymentsnz.co.nz/join/"
+  version: v2.2.1
+basePath: /open-banking-nz/v2.2
+schemes:
+  - https
+consumes:
+  - application/json; charset=utf-8
+produces:
+  - application/json; charset=utf-8
+tags:
+  - name: Account Access Consents
+    description: >-
+      A consent to access account information resources
+  - name: Accounts
+    description: >-
+      A resource that represents the account to which credit and debit entries are
+      made
+  - name: Balances
+    description: >-
+      A resource that represents the net increases and decreases in an account at a
+      specific point in time
+  - name: Beneficiaries
+    description: >-
+      A set of elements that describe the list of trusted beneficiaries linked to a
+      specific account
+  - name: Direct Debits
+    description: >-
+      A set of elements that describe the list of direct-debits that have been set up
+      on a specific account
+  - name: Offers
+    description: >-
+      A set of elements that descirbe the list of offers avaialble to a specific
+      account
+  - name: Party
+    description: >-
+      A set of elements that describe the party linked to a specific account
+  - name: Scheduled Payments
+    description: >-
+      A set of elements that describe the list of scheduled-payments that have been
+      set up on a specific account
+  - name: Standing Orders
+    description: >-
+      A set of elements that describe the list of standing-orders that have been set
+      up on a specific account
+  - name: Statements
+    description: >-
+      A resource that describes summary details for an account statement period
+  - name: Transactions
+    description: >-
+      A resource that describes a posting to an account that results in an increase
+      or decrease to a balance
+paths:
+  "/account-access-consents":
+    post:
+      tags:
+        - Account Access Consents
+      operationId: CreateAccountAccessConsent
+      summary: Create an account access consent
+      description: >-
+        The account-access-consents resource represents a consent that has been
+        agreed between the Customer and the Third Party for the Third Party to
+        access a Customer's account information with an API Provider.
+      parameters:
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+        - name: body
+          in: body
+          description: Account Access Consent Body
+          required: true
+          schema:
+            title: Account Access Consent
+            type: object
+            properties:
+              Data:
+                $ref: "#/definitions/AccountAccessConsentModel"
+              Risk:
+                $ref: "#/definitions/Risk"
+            required:
+              - Data
+              - Risk
+            additionalProperties: false
+      responses:
+        "201":
+          description: Account Access Consent successfully created
+          schema:
+            title: Account Access Consent POST response
+            type: object
+            properties:
+              Data:
+                $ref: "#/definitions/AccountAccessConsentResponseModel"
+              Risk:
+                $ref: "#/definitions/Risk"
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Risk
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "415":
+          $ref: "#/responses/415ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - ThirdPartyOAuth2Security:
+            - accounts
+  "/account-access-consents/{ConsentId}":
+    get:
+      tags:
+        - Account Access Consents
+      operationId: GetAccountAccessConsent
+      summary: Get an account access consent
+      description: Retrieve an account access consent and check its status.
+      parameters:
+        - $ref: "#/parameters/ConsentIdParam"
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account Access Consent successfully retrieved
+          schema:
+            title: Account Access Consent GET response
+            type: object
+            properties:
+              Data:
+                $ref: "#/definitions/AccountAccessConsentResponseModel"
+              Risk:
+                $ref: "#/definitions/Risk"
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Risk
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - ThirdPartyOAuth2Security:
+            - accounts
+    delete:
+      tags:
+        - Account Access Consents
+      operationId: DeleteAccountAccessConsent
+      summary: Delete an account access consent
+      description: Delete an account access consent
+      parameters:
+        - $ref: "#/parameters/ConsentIdParam"
+        - $ref: "#/parameters/AuthorizationParam"
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+      responses:
+        "204":
+          description: Account Access Consent successfully deleted
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - ThirdPartyOAuth2Security:
+            - accounts
+  "/accounts":
+    get:
+      tags:
+        - Accounts
+      operationId: GetAccounts
+      summary: Get Accounts
+      description: Get a list of accounts
+      parameters:
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Accounts successfully retrieved
+          schema:
+            title: Account GET response
+            type: object
+            properties:
+              Data:
+                title: Data
+                type: object
+                description: Data
+                properties:
+                  Account:
+                    title: Account
+                    description: Account
+                    type: array
+                    items:
+                      $ref: "#/definitions/AccountModel"
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/accounts/{AccountId}":
+    get:
+      tags:
+        - Accounts
+      operationId: GetAccount
+      summary: Get Account
+      description: Get an account
+      parameters:
+        - $ref: "#/parameters/AccountIdParam"
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account resource successfully retrieved
+          schema:
+            title: Account GET response
+            type: object
+            properties:
+              Data:
+                title: Data
+                description: Data
+                type: object
+                properties:
+                  Account:
+                    $ref: "#/definitions/AccountModel"
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/accounts/{AccountId}/transactions":
+    get:
+      tags:
+        - Transactions
+      operationId: GetAccountTransactions
+      summary: Get Account Transactions
+      description: Get transactions related to an account
+      parameters:
+        - $ref: "#/parameters/AccountIdParam"
+        - $ref: "#/parameters/FromBookingDateTimeParam"
+        - $ref: "#/parameters/ToBookingDateTimeParam"
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account Transactions successfully retrieved
+          schema:
+            title: Transactions GET response
+            type: object
+            properties:
+              Data:
+                title: Data
+                description: Data
+                type: object
+                properties:
+                  Transaction:
+                    title: Transaction
+                    description: Transaction
+                    type: array
+                    items:
+                      $ref: "#/definitions/TransactionModel"
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/accounts/{AccountId}/beneficiaries":
+    get:
+      tags:
+        - Beneficiaries
+      operationId: GetAccountBeneficiaries
+      summary: Get Account Beneficiaries
+      description: Get Beneficiaries related to an account
+      parameters:
+        - $ref: "#/parameters/AccountIdParam"
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account Beneficiaries  successfully retrieved
+          schema:
+            title: Beneficiaries GET response
+            type: object
+            properties:
+              Data:
+                title: Data
+                description: Data
+                type: object
+                properties:
+                  Beneficiary:
+                    title: Beneficiary
+                    description: Beneficiary
+                    type: array
+                    items:
+                      $ref: "#/definitions/BeneficiaryModel"
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/accounts/{AccountId}/balances":
+    get:
+      tags:
+        - Balances
+      operationId: GetAccountBalances
+      summary: Get Account Balances
+      description: Get Balances related to an account
+      parameters:
+        - $ref: "#/parameters/AccountIdParam"
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account Balances successfully retrieved
+          schema:
+            title: Balances GET response
+            type: object
+            properties:
+              Data:
+                title: Data
+                description: Data
+                type: object
+                properties:
+                  Balance:
+                    title: Balance
+                    description: Balance
+                    type: array
+                    items:
+                      $ref: "#/definitions/BalanceModel"
+                required:
+                  - Balance
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/accounts/{AccountId}/direct-debits":
+    get:
+      tags:
+        - Direct Debits
+      operationId: GetAccountDirectDebits
+      summary: Get Account Direct Debits
+      description: Get Direct Debits related to an account
+      parameters:
+        - $ref: "#/parameters/AccountIdParam"
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account Direct Debits successfully retrieved
+          schema:
+            title: Direct Debit GET response
+            type: object
+            properties:
+              Data:
+                title: Data
+                description: Data
+                type: object
+                properties:
+                  DirectDebit:
+                    title: DirectDebit
+                    description: DirectDebit
+                    type: array
+                    items:
+                      $ref: "#/definitions/DirectDebitModel"
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/accounts/{AccountId}/standing-orders":
+    get:
+      tags:
+        - Standing Orders
+      operationId: GetAccountStandingOrders
+      summary: Get Account Standing Orders
+      description: Get Standing Orders related to an account
+      parameters:
+        - $ref: "#/parameters/AccountIdParam"
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account Standing Orders successfully retrieved
+          schema:
+            title: Standing Orders GET response
+            type: object
+            properties:
+              Data:
+                title: Data
+                description: Data
+                type: object
+                properties:
+                  StandingOrder:
+                    title: StandingOrder
+                    description: StandingOrder
+                    type: array
+                    items:
+                      $ref: "#/definitions/StandingOrderModel"
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/accounts/{AccountId}/offers":
+    get:
+      tags:
+        - Offers
+      operationId: GetAccountOffers
+      summary: Get Account Offers
+      description: Get Offers related to an account
+      parameters:
+        - $ref: "#/parameters/AccountIdParam"
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account Offers successfully retrieved
+          schema:
+            type: object
+            properties:
+              Data:
+                type: object
+                properties:
+                  Offer:
+                    items:
+                      $ref: "#/definitions/OfferModel"
+                    type: array
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/accounts/{AccountId}/party":
+    get:
+      tags:
+        - Party
+      operationId: GetAccountParty
+      summary: Get Account Party
+      description: Get Party related to an account
+      parameters:
+        - $ref: "#/parameters/AccountIdParam"
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account Party successfully retrieved
+          schema:
+            type: object
+            properties:
+              Data:
+                type: object
+                properties:
+                  Party:
+                    $ref: "#/definitions/PartyModel"
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/accounts/{AccountId}/scheduled-payments":
+    get:
+      tags:
+        - Scheduled Payments
+      operationId: GetAccountScheduledPayments
+      summary: Get Account Scheduled Payments
+      description: Get Scheduled Payments related to an account
+      parameters:
+        - $ref: "#/parameters/AccountIdParam"
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account Scheduled Payment successfully retrieved
+          schema:
+            type: object
+            properties:
+              Data:
+                type: object
+                properties:
+                  ScheduledPayment:
+                    items:
+                      $ref: "#/definitions/ScheduledPaymentModel"
+                    type: array
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/accounts/{AccountId}/statements":
+    get:
+      tags:
+        - Statements
+      operationId: GetAccountStatements
+      summary: Get Account Statements
+      description: Get Statements related to an account
+      parameters:
+        - $ref: "#/parameters/AccountIdParam"
+        - $ref: "#/parameters/FromStatementDateTimeParam"
+        - $ref: "#/parameters/ToStatementDateTimeParam"
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account Statement successfully retrieved
+          schema:
+            type: object
+            properties:
+              Data:
+                type: object
+                properties:
+                  Statement:
+                    items:
+                      $ref: "#/definitions/StatementModel"
+                    type: array
+                    description: Provides further details on a statement resource.
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/accounts/{AccountId}/statements/{StatementId}":
+    get:
+      tags:
+        - Statements
+      operationId: GetAccountStatement
+      summary: Get Statement
+      description: Get Statement related to an account
+      parameters:
+        - $ref: "#/parameters/AccountIdParam"
+        - $ref: "#/parameters/StatementIdParam"
+        - $ref: "#/parameters/FromStatementDateTimeParam"
+        - $ref: "#/parameters/ToStatementDateTimeParam"
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account Statement successfully retrieved
+          schema:
+            type: object
+            properties:
+              Data:
+                type: object
+                properties:
+                  Statement:
+                    $ref: "#/definitions/StatementModel"
+                    description: Provides further details on a statement resource.
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/accounts/{AccountId}/statements/{StatementId}/file":
+    get:
+      tags:
+        - Statements
+      operationId: GetAccountStatementFile
+      summary: Get Statement File
+      description: Get Statement related to an account
+      produces:
+        - "*/*"
+      parameters:
+        - $ref: "#/parameters/AccountIdParam"
+        - $ref: "#/parameters/StatementIdParam"
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account Statement File successfully retrieved
+          schema:
+            type: file
+            description: Statement File
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/accounts/{AccountId}/statements/{StatementId}/transactions":
+    get:
+      tags:
+        - Statements
+        - Transactions
+      operationId: GetAccountStatementTransactions
+      summary: Get Statement Transactions
+      description: Get Statement Transactions related to an account
+      parameters:
+        - $ref: "#/parameters/AccountIdParam"
+        - $ref: "#/parameters/StatementIdParam"
+        - $ref: "#/parameters/FromBookingDateTimeParam"
+        - $ref: "#/parameters/ToBookingDateTimeParam"
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account Transactions successfully retrieved
+          schema:
+            type: object
+            properties:
+              Data:
+                type: object
+                properties:
+                  Transaction:
+                    items:
+                      $ref: "#/definitions/TransactionModel"
+                    type: array
+                    description: Provides further details on an entry in the report.
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/standing-orders":
+    get:
+      tags:
+        - Standing Orders
+      operationId: GetStandingOrders
+      summary: Get Standing Orders
+      description: Get Standing Orders
+      parameters:
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Standing Orders successfully retrieved
+          schema:
+            title: Standing Orders GET response
+            type: object
+            properties:
+              Data:
+                title: Data
+                description: Data
+                type: object
+                properties:
+                  StandingOrder:
+                    title: StandingOrder
+                    description: StandingOrder
+                    type: array
+                    items:
+                      $ref: "#/definitions/StandingOrderModel"
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            additionalProperties: false
+            required:
+              - Data
+              - Links
+              - Meta
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/direct-debits":
+    get:
+      tags:
+        - Direct Debits
+      operationId: GetDirectDebits
+      summary: Get Direct Debits
+      description: Get Direct Debits
+      parameters:
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Direct Debits successfully retrieved
+          schema:
+            title: Direct Debit GET response
+            type: object
+            properties:
+              Data:
+                title: Data
+                description: Data
+                type: object
+                properties:
+                  DirectDebit:
+                    title: DirectDebit
+                    description: DirectDebit
+                    type: array
+                    items:
+                      $ref: "#/definitions/DirectDebitModel"
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/beneficiaries":
+    get:
+      tags:
+        - Beneficiaries
+      operationId: GetBeneficiaries
+      summary: Get Beneficiaries
+      description: Get Beneficiaries
+      parameters:
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Beneficiaries successfully retrieved
+          schema:
+            title: Beneficiaries GET response
+            type: object
+            properties:
+              Data:
+                title: Data
+                description: Data
+                type: object
+                properties:
+                  Beneficiary:
+                    title: Beneficiary
+                    description: Beneficiary
+                    type: array
+                    items:
+                      $ref: "#/definitions/BeneficiaryModel"
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/transactions":
+    get:
+      tags:
+        - Transactions
+      operationId: GetTransactions
+      summary: Get Transactions
+      description: Get Transactions
+      parameters:
+        - $ref: "#/parameters/FromBookingDateTimeParam"
+        - $ref: "#/parameters/ToBookingDateTimeParam"
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Transactions successfully retrieved
+          schema:
+            title: Transactions GET response
+            type: object
+            properties:
+              Data:
+                title: Data
+                description: Data
+                type: object
+                properties:
+                  Transaction:
+                    title: Transaction
+                    description: Transaction
+                    type: array
+                    items:
+                      $ref: "#/definitions/TransactionModel"
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/balances":
+    get:
+      tags:
+        - Balances
+      operationId: GetBalances
+      summary: Get Balances
+      description: Get Balances
+      parameters:
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Balances successfully retrieved
+          schema:
+            title: Balances GET response
+            type: object
+            properties:
+              Data:
+                title: Data
+                description: Data
+                type: object
+                properties:
+                  Balance:
+                    title: Balance
+                    description: Balance
+                    type: array
+                    items:
+                      $ref: "#/definitions/BalanceModel"
+                required:
+                  - Balance
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            additionalProperties: false
+            required:
+              - Data
+              - Links
+              - Meta
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/offers":
+    get:
+      tags:
+        - Offers
+      operationId: GetOffers
+      summary: Get Offers
+      description: Get Offers
+      parameters:
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account Offers successfully retrieved
+          schema:
+            type: object
+            properties:
+              Data:
+                type: object
+                properties:
+                  Offer:
+                    items:
+                      $ref: "#/definitions/OfferModel"
+                    type: array
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/party":
+    get:
+      tags:
+        - Party
+      operationId: GetParty
+      summary: Get Party
+      description: Get Party of logged in Customer
+      parameters:
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account Party successfully retrieved
+          schema:
+            type: object
+            properties:
+              Data:
+                type: object
+                properties:
+                  Party:
+                    $ref: "#/definitions/PartyModel"
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/scheduled-payments":
+    get:
+      tags:
+        - Scheduled Payments
+      operationId: GetScheduledPayments
+      summary: Get Scheduled Payments
+      description: Get Scheduled Payments
+      parameters:
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account Scheduled Payment successfully retrieved
+          schema:
+            type: object
+            properties:
+              Data:
+                type: object
+                properties:
+                  ScheduledPayment:
+                    items:
+                      $ref: "#/definitions/ScheduledPaymentModel"
+                    type: array
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/statements":
+    get:
+      tags:
+        - Statements
+      summary: Get Statements
+      description: Get Statements
+      operationId: GetStatements
+      parameters:
+        - $ref: "#/parameters/FromStatementDateTimeParam"
+        - $ref: "#/parameters/ToStatementDateTimeParam"
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account Statement successfully retrieved
+          schema:
+            type: object
+            properties:
+              Data:
+                type: object
+                properties:
+                  Statement:
+                    items:
+                      $ref: "#/definitions/StatementModel"
+                    type: array
+                    description: Provides further details on a statement.
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+parameters:
+  AccountIdParam:
+    name: AccountId
+    in: path
+    description: A unique identifier used to identify the account resource.
+    required: true
+    type: string
+  ConsentIdParam:
+    name: ConsentId
+    in: path
+    description: >-
+      Unique identification as assigned by the API Provider to uniquely identify the
+      account access consent.
+    required: true
+    type: string
+  FromBookingDateTimeParam:
+    in: query
+    name: fromBookingDateTime
+    type: string
+    format: date-time
+    description: >-
+      The UTC ISO 8601 Date Time to filter transactions FROM
+      NB Time component is optional - set to 00:00:00 for just Date.
+      If the Date Time contains a timezone, the API Provider must ignore the timezone
+      component.
+  StatementIdParam:
+    name: StatementId
+    in: path
+    description: A unique identifier used to identify the statement resource.
+    required: true
+    type: string
+  ToBookingDateTimeParam:
+    in: query
+    name: toBookingDateTime
+    type: string
+    format: date-time
+    description: >-
+      The UTC ISO 8601 Date Time to filter transactions TO
+      NB Time component is optional - set to 00:00:00 for just Date.
+      If the Date Time contains a timezone, the API Provider must ignore the timezone
+      component.
+  FromStatementDateTimeParam:
+    in: query
+    name: fromStatementDateTime
+    type: string
+    format: date-time
+    description: >-
+      The UTC ISO 8601 Date Time to filter statements FROM
+      NB Time component is optional - set to 00:00:00 for just Date.
+      If the Date Time contains a timezone, the API Provider must ignore the timezone
+      component.
+  ToStatementDateTimeParam:
+    in: query
+    name: toStatementDateTime
+    type: string
+    format: date-time
+    description: >-
+      The UTC ISO 8601 Date Time to filter statements TO
+      NB Time component is optional - set to 00:00:00 for just Date.
+      If the Date Time contains a timezone, the API Provider must ignore the timezone
+      component.
+  x-fapi-customer-ip-address-Param:
+    in: header
+    name: x-fapi-customer-ip-address
+    type: string
+    required: false
+    description: The Customer's IP address if the Customer is currently logged in with the Third Party.
+    pattern: ^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$
+  x-fapi-interaction-id-Param:
+    in: header
+    name: x-fapi-interaction-id
+    type: string
+    required: false
+    description: An RFC4122 UID used as a correlation id.
+  x-fapi-auth-date-Param:
+    in: header
+    name: x-fapi-auth-date
+    type: string
+    required: false
+    description: >-
+      The time when the Customer last logged in with the Third Party.
+
+      All dates in the HTTP headers are represented as RFC 7231 Full Dates. An
+      example is below:
+
+      Sun, 10 Sep 2017 19:43:31 UTC
+    pattern: >-
+      ^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), \d{2}
+      (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{4} \d{2}:\d{2}:\d{2}
+      (GMT|UTC)$
+  x-merchant-ip-address-Param:
+    in: header
+    name: x-merchant-ip-address
+    type: string
+    required: false
+    description: >-
+      The IP address of the merchant when making account information requests through a
+      Third Party.
+    pattern: ^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$
+  x-customer-user-agent-Param:
+    in: header
+    name: x-customer-user-agent
+    type: string
+    required: false
+    description: >-
+      The User-Agent of the application on the customer device that is used to
+      make the account information request
+  AuthorizationParam:
+    in: header
+    name: Authorization
+    type: string
+    required: true
+    description: "An Authorisation Token as per https://tools.ietf.org/html/rfc6750"
+definitions:
+  Error:
+    type: object
+    properties:
+      ErrorCode:
+        description: >-
+          Low level textual error code.
+        type: string
+        enum:
+          - Field.Expected
+          - Field.Invalid
+          - Field.Missing
+          - Field.Unexpected
+          - Header.Invalid
+          - Header.Missing
+          - QueryParam.Invalid
+          - Reauthenticate
+          - Reauthorise
+          - Resource.Consent.CreditorAccount
+          - Resource.Consent.DebtorAccount
+          - Resource.Consent.Exceed.DataPermissions
+          - Resource.Consent.Exceed.Dates
+          - Resource.Consent.Exceed.Frequency
+          - Resource.Consent.Exceed.MaximumAmount
+          - Resource.Consent.Exceed.TotalAmount
+          - Resource.Consent.Exceed.TotalCount
+          - Resource.Consent.Exceed.TransactionDates
+          - Resource.Consent.InvalidStatus
+          - Resource.Consent.Mismatch
+          - Resource.Invalid
+          - UnexpectedError
+          - Unsupported.AccountIdentifier
+          - Unsupported.AccountSecondaryIdentifier
+          - Unsupported.Currency
+          - Unsupported.Scheme
+      Message:
+        description: >-
+          A free text description of the error that occurred. E.g.,
+          'A mandatory field isn't supplied'.
+        type: string
+        minLength: 1
+        maxLength: 500
+      Path:
+        description: >-
+          A recommended but optional reference to the JSON Path of the field
+          with error, e.g., Data.Consent.InstructedAmount.Currency
+        type: string
+        minLength: 1
+        maxLength: 500
+      Url:
+        description: >-
+          URL to help remediate the problem, provide more information or to
+          API Reference.
+        type: string
+    required:
+      - ErrorCode
+      - Message
+    additionalProperties: false
+    minProperties: 1
+  ErrorResponse:
+    description: >-
+      An array of detail error codes, and messages, and URLs to documentation to
+      help remediation.
+    type: object
+    properties:
+      Code:
+        description: >-
+          High level textual error code to help categorise the errors.
+        type: string
+        minLength: 1
+        maxLength: 128
+      Id:
+        description: >-
+          A unique reference for the error instance, for audit purposes, in
+          case of unknown/unclassified errors.
+        type: string
+        minLength: 1
+        maxLength: 128
+      Message:
+        description: >-
+          Brief Error message. E.g., 'There is something wrong with the request
+          parameters provided'
+        type: string
+        minLength: 1
+        maxLength: 500
+      Errors:
+        items:
+          $ref: "#/definitions/Error"
+        type: array
+        minItems: 1
+    required:
+      - Code
+      - Message
+      - Errors
+    additionalProperties: false
+  BalanceModel:
+    type: object
+    description: Balance object schema
+    properties:
+      AccountId:
+        description: >-
+          A unique and immutable identifier used to identify the account
+          resource. This identifier has no meaning to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      Amount:
+        description: Amount of money of the cash balance.
+        type: object
+        properties:
+          Amount:
+            type: string
+            pattern: '^\d{1,13}\.\d{1,5}$'
+          Currency:
+            description: >-
+              A code allocated to a currency by a Maintenance Agency under an
+              international identification scheme, as described in the latest
+              edition of the international standard ISO 4217 'Codes for the
+              representation of currencies and funds'
+            type: string
+            pattern: "^[A-Z]{3,3}$"
+        required:
+          - Amount
+          - Currency
+        additionalProperties: false
+      CreditDebitIndicator:
+        description: >-
+          Indicates whether the balance is a credit or a debit balance. Usage: A
+          zero balance is considered to be a credit balance.
+        type: string
+        enum:
+          - Credit
+          - Debit
+      Type:
+        description: "Balance type, in a coded form."
+        type: string
+        enum:
+          - ClosingAvailable
+          - ClosingBooked
+          - Expected
+          - ForwardAvailable
+          - Information
+          - InterimAvailable
+          - InterimBooked
+          - OpeningAvailable
+          - OpeningBooked
+          - PreviouslyClosedBooked
+      DateTime:
+        description: >-
+          Indicates the date (and time) of the balance.
+
+          All dates in the JSON payloads are represented in ISO 8601 date-time
+          format.
+
+          All date-time fields in responses must include the timezone. An
+          example is below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      CreditLine:
+        type: array
+        items:
+          type: object
+          properties:
+            Included:
+              description: >-
+                Indicates whether or not the credit line is included in the
+                balance of the account. Usage: If not present, credit line is
+                not included in the balance amount of the account.
+              type: boolean
+            Amount:
+              description: Active Or Historic Currency Code and Amount
+              type: object
+              properties:
+                Amount:
+                  type: string
+                  pattern: '^\d{1,13}\.\d{1,5}$'
+                Currency:
+                  description: >-
+                    A code allocated to a currency by a Maintenance Agency under
+                    an international identification scheme, as described in the
+                    latest edition of the international standard ISO 4217 'Codes
+                    for the representation of currencies and funds'
+                  type: string
+                  pattern: "^[A-Z]{3,3}$"
+              required:
+                - Amount
+                - Currency
+              additionalProperties: false
+            Type:
+              description: "Limit type, in a coded form."
+              type: string
+              enum:
+                - Pre-Agreed
+                - Emergency
+                - Temporary
+              additionalProperties: false
+          required:
+            - Included
+          additionalProperties: false
+    required:
+      - AccountId
+      - Amount
+      - CreditDebitIndicator
+      - DateTime
+      - Type
+    minItems: 1
+    additionalProperties: false
+  AccountModel:
+    type: object
+    properties:
+      AccountId:
+        description: >-
+          A unique and immutable identifier used to identify the account
+          resource. This identifier has no meaning to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      Currency:
+        description: >-
+          Identification of the currency in which the account is held.  Usage:
+          Currency should only be used in case one and the same account number
+          covers several currencies and the initiating party needs to identify
+          which currency needs to be used for settlement on the account.
+        type: string
+        pattern: "^[A-Z]{3,3}$"
+      AccountType:
+        description: Specifies the type of account (personal or business).
+        type: string
+        enum:
+          - Business
+          - Personal
+      AccountSubType:
+        description: Specifies the sub type of account (product family group).
+        type: string
+        enum:
+          - ChargeCard
+          - CreditCard
+          - CurrentAccount
+          - EMoney
+          - Loan
+          - Mortgage
+          - PrePaidCard
+          - Savings
+      Description:
+        description: Specifies the description of the account type.
+        type: string
+        minLength: 1
+        maxLength: 35
+      Nickname:
+        description: >-
+          The nickname of the account, assigned by the account owner in order to
+          provide an additional means of identification of the account.
+        type: string
+        minLength: 1
+        maxLength: 70
+      Account:
+        description: Provides the details to identify an account.
+        type: object
+        properties:
+          SchemeName:
+            $ref: "#/definitions/AccountSchemeModel"
+          Identification:
+            description: >-
+              Identification assigned by an institution to
+              identify an account. This identification is
+              known by the account owner.
+            type: string
+            minLength: 1
+            maxLength: 34
+          Name:
+            description: >-
+              Name of the account, as assigned by the account servicing
+              institution, in agreement with the account owner in order to
+              provide an additional means of identification of the account.
+              Usage: The account name is different from the account owner name.
+              The account name is used in certain user communities to provide a
+              means of identifying the account, in addition to the account
+              owner's identity and the account number.
+            type: string
+            minLength: 1
+            maxLength: 70
+          SecondaryIdentification:
+            description: >-
+              This is secondary identification of the account, as assigned by
+              the account servicing institution.
+            type: string
+            minLength: 1
+            maxLength: 34
+        required:
+          - SchemeName
+          - Identification
+        additionalProperties: false
+      Servicer:
+        description: >-
+          Party that manages the account on behalf of the account owner, that is
+          manages the registration and booking of entries on the account,
+          calculates balances on the account and provides information about the
+          account.
+        type: object
+        properties:
+          SchemeName:
+            description: >-
+              Name of the identification scheme, in a coded form as published in
+              an external list.
+            type: string
+            enum:
+              - BICFI
+          Identification:
+            description: >-
+              Unique and unambiguous identification of the servicing
+              institution.
+            type: string
+            minLength: 1
+            maxLength: 35
+        required:
+          - SchemeName
+          - Identification
+        additionalProperties: false
+    additionalProperties: false
+    required:
+      - AccountId
+      - Currency
+      - Nickname
+  AccountSchemeModel:
+    type: string
+    enum:
+      - BECSElectronicCredit
+      - MaskedCardNumber
+  Links:
+    title: Links
+    type: object
+    description: Links relevant to the payload
+    properties:
+      Self:
+        type: string
+        format: uri
+      First:
+        type: string
+        format: uri
+      Prev:
+        type: string
+        format: uri
+      Next:
+        type: string
+        format: uri
+      Last:
+        type: string
+        format: uri
+    required:
+      - Self
+  Risk:
+    type: object
+    description: >-
+      The Risk section is sent by the initiating party to the API Provider.
+      It is used to specify additional details for risk scoring.
+    properties:
+      GeoLocation:
+        description: >-
+          Location of the end-user on the earth specified by two numbers
+          representing vertical and horizontal position
+        type: object
+        properties:
+          Latitude:
+            description: Latitude measured in decimal degress
+            type: string
+            maxLength: 14
+            pattern: '^-?\d{1,3}\.\d{1,8}$'
+          Longitude:
+            description: Longitude measured in decimal degress
+            type: string
+            maxLength: 14
+            pattern: '^-?\d{1,3}\.\d{1,8}$'
+      PaymentContextCode:
+        description: Specifies the payment context
+        title: PaymentContextCode
+        type: string
+        enum:
+          - BillPayment
+          - EcommerceGoods
+          - EcommerceServices
+          - Other
+          - PersonToPerson
+      MerchantCategoryCode:
+        description: >-
+          Category code conforms to ISO 18245, related to the type of services
+          or goods the merchant provides for the transaction
+        type: string
+        minLength: 3
+        maxLength: 4
+      MerchantCustomerIdentification:
+        description: The unique customer identifier of the Customer with the merchant.
+        type: string
+        minLength: 1
+        maxLength: 70
+      DeliveryAddress:
+        description: >-
+          Information that locates and identifies a specific
+          address, as defined by postal services or in free format
+          text.
+        type: object
+        properties:
+          AddressType:
+            description: >-
+              Identifies the nature of the postal address.
+            type: string
+            enum:
+              - DeliveryTo
+          AddressLine:
+            description: >-
+              Information that locates and identifies a specific
+              address, as defined by postal services, that is
+              presented in free format text.
+            type: array
+            items:
+              type: string
+              minLength: 1
+              maxLength: 70
+            minItems: 0
+            maxItems: 5
+          StreetName:
+            description: >-
+              Name of a street or thoroughfare.
+            type: string
+            minLength: 1
+            maxLength: 70
+          BuildingNumber:
+            description: >-
+              Number that identifies the position of a building on a
+              street.
+            type: string
+            minLength: 1
+            maxLength: 16
+          PostCode:
+            description: >-
+              Identifier consisting of a group of letters and/or
+              numbers that is added to a postal address to assist
+              the sorting of mail
+            type: string
+            minLength: 1
+            maxLength: 16
+          TownName:
+            description: >-
+              Name of a built-up area, with defined boundaries, and
+              a local government.
+            type: string
+            minLength: 1
+            maxLength: 35
+          CountrySubDivision:
+            description: >-
+              Identifies a subdivision of a country, for instance
+              state, region, county.
+            type: string
+            minLength: 1
+            maxLength: 35
+          Country:
+            description: >-
+              Nation with its own government, occupying a particular
+              territory.
+            type: string
+            pattern: "^[A-Z]{2,2}$"
+        required:
+          - Country
+        additionalProperties: false
+      EndUserAppName:
+        description: Name of the end user facing application
+        type: string
+        minLength: 1
+        maxLength: 70
+      EndUserAppVersion:
+        description: Version of the end user facing application
+        type: string
+        minLength: 1
+        maxLength: 14
+      MerchantName:
+        description: Name of the merchant
+        type: string
+        minLength: 1
+        maxLength: 70
+      MerchantNZBN:
+        description: NZ business number for the merchant
+        type: string
+        minLength: 1
+        maxLength: 70
+    additionalProperties: false
+  AccountAccessConsentModel:
+    type: object
+    properties:
+      Consent:
+        description: >-
+          Contains the requested consent
+        type: object
+        properties:
+          Permissions:
+            description: >-
+              Specifies the Open Banking account access consent types. This is a
+              list of the data clusters being consented by the Customer, and requested
+              for authorisation with the API Provider.
+            type: array
+            items:
+              description: >-
+                Specifies the Open Banking account access consent types. This is a
+                list of the data clusters being consented by the Customer, and
+                requested for authorisation with the API Provider.
+              type: string
+              enum:
+                - ReadAccountsBasic
+                - ReadAccountsDetail
+                - ReadBalances
+                - ReadBeneficiariesBasic
+                - ReadBeneficiariesDetail
+                - ReadDirectDebits
+                - ReadOffers
+                - ReadParty
+                - ReadPartyAuthUser
+                - ReadScheduledPaymentsBasic
+                - ReadScheduledPaymentsDetail
+                - ReadStandingOrdersBasic
+                - ReadStandingOrdersDetail
+                - ReadStatementsBasic
+                - ReadStatementsDetail
+                - ReadTransactionsBasic
+                - ReadTransactionsCredits
+                - ReadTransactionsDebits
+                - ReadTransactionsDetail
+              minProperties: 1
+              additionalProperties: false
+          ExpirationDateTime:
+            description: >-
+              Specified date and time the permissions will expire. If this is not
+              populated, the permissions will be open ended.
+
+              All dates in the JSON payloads are represented in ISO 8601 date-time
+              format.
+
+              All date-time fields in responses must include the timezone. An
+              example is below:
+
+              2017-04-05T10:43:07+00:00
+            type: string
+            format: date-time
+          TransactionFromDateTime:
+            description: >-
+              Specified start date and time for the transaction query period. If
+              this is not populated, the start date will be open ended, and data
+              will be returned from the earliest available transaction.
+
+              All dates in the JSON payloads are represented in ISO 8601 date-time
+              format.
+
+              All date-time fields in responses must include the timezone. An
+              example is below:
+
+              2017-04-05T10:43:07+00:00
+            type: string
+            format: date-time
+          TransactionToDateTime:
+            description: >-
+              Specified end date and time for the transaction query period. If this
+              is not populated, the end date will be open ended, and data will be
+              returned to the latest available transaction.
+
+              All dates in the JSON payloads are represented in ISO 8601 date-time
+              format.
+
+              All date-time fields in responses must include the timezone. An
+              example is below:
+
+              2017-04-05T10:43:07+00:00
+            type: string
+            format: date-time
+        required:
+          - Permissions
+        additionalProperties: false
+    additionalProperties: false
+    required:
+      - Consent
+  AccountAccessConsentResponseModel:
+    type: object
+    allOf:
+      - properties:
+          ConsentId:
+            description: >-
+              Unique identification as assigned to identify the account access consent.
+            type: string
+            minLength: 1
+            maxLength: 128
+          Status:
+            description: Specifies the status of the account access consent.
+            type: string
+            enum:
+              - Authorised
+              - AwaitingAuthorisation
+              - Rejected
+              - Revoked
+          CreationDateTime:
+            description: >-
+              Date and time at which the consent was created.
+
+              All dates in the JSON payloads are represented in ISO 8601
+              date-time format.
+
+              All date-time fields in responses must include the timezone. An
+              example is below:
+
+              2017-04-05T10:43:07+00:00
+            type: string
+            format: date-time
+          StatusUpdateDateTime:
+            description: >-
+              Date and time at which the consent status was updated.
+
+              All dates in the JSON payloads are represented in ISO 8601 date-time
+              format.
+
+              All date-time fields in responses must include the timezone. An
+              example is below:
+
+              2017-04-05T10:43:07+00:00
+            type: string
+            format: date-time
+        required:
+          - ConsentId
+          - Status
+          - CreationDateTime
+          - StatusUpdateDateTime
+        additionalProperties: false
+      - $ref: "#/definitions/AccountAccessConsentModel"
+  TransactionModel:
+    type: object
+    properties:
+      AccountId:
+        description: >-
+          A unique and immutable identifier used to identify
+          the account resource. This identifier has no meaning
+          to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      TransactionId:
+        description: >-
+          Unique identifier for the transaction within an
+          servicing institution. This identifier is both
+          unique and immutable.
+        type: string
+        minLength: 1
+        maxLength: 40
+      TransactionReference:
+        $ref: "#/definitions/BECSRemittance"
+      StatementReference:
+        type: array
+        items:
+          description: >-
+            Unique reference for the statement. This reference may be optionally
+            populated if available.
+          type: string
+          minLength: 1
+          maxLength: 35
+        description: >-
+          Unique reference for the statement. This reference may be optionally
+          populated if available.
+      Amount:
+        description: Amount of money in the cash entry.
+        type: object
+        properties:
+          Amount:
+            type: string
+            pattern: '^\d{1,13}\.\d{1,5}$'
+          Currency:
+            description: >-
+              A code allocated to a currency by a Maintenance
+              Agency under an international identification
+              scheme, as described in the latest edition of
+              the international standard ISO 4217 'Codes for
+              the representation of currencies and funds'
+            type: string
+            pattern: "^[A-Z]{3,3}$"
+        required:
+          - Amount
+          - Currency
+        additionalProperties: false
+      CreditDebitIndicator:
+        description: >-
+          Indicates whether the transaction is a credit or a
+          debit entry.
+        type: string
+        enum:
+          - Credit
+          - Debit
+      Status:
+        description: >-
+          Status of a transaction entry on the books of the
+          account servicer.
+        type: string
+        enum:
+          - Booked
+          - Pending
+      BookingDateTime:
+        description: >-
+          Date and time when a transaction entry is posted to
+          an account on the account servicer's books. Usage:
+          Booking date is the expected booking date, unless
+          the status is booked, in which case it is the actual
+          booking date.
+
+          All dates in the JSON payloads are represented in
+          ISO 8601 date-time format.
+
+          All date-time fields in responses must include the
+          timezone. An example is below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      ValueDateTime:
+        description: >-
+          Date and time at which assets become available to
+          the account owner in case of a credit entry, or
+          cease to be available to the account owner in case
+          of a debit entry.  Usage: If entry status is pending
+          and value date is present, then the value date
+          refers to an expected/requested value date. For
+          entries subject to availability/float and for which
+          availability information is provided, the value date
+          must not be used. In this case the availability
+          component identifies the  number of availability
+          days.
+
+          All dates in the JSON payloads are represented in
+          ISO 8601 date-time format.
+
+          All date-time fields in responses must include the
+          timezone. An example is below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      AddressLine:
+        description: >-
+          Information that locates and identifies a specific
+          address, as defined by postal services, that is
+          presented in free format text.
+        type: string
+        minLength: 1
+        maxLength: 70
+      BankTransactionCode:
+        description: >-
+          Set of elements used to fully identify the type of
+          underlying transaction resulting in an entry.
+        type: object
+        properties:
+          Code:
+            description: Specifies the family within a domain.
+            type: string
+          SubCode:
+            description: >-
+              Specifies the sub-product family within a
+              specific family.
+            type: string
+        required:
+          - Code
+          - SubCode
+        additionalProperties: false
+      ProprietaryBankTransactionCode:
+        description: >-
+          Set of elements to fully identify a proprietary bank
+          transaction code.
+        type: object
+        properties:
+          Code:
+            description: >-
+              Proprietary bank transaction code to identify
+              the underlying transaction.
+            type: string
+            minLength: 1
+            maxLength: 35
+          Issuer:
+            description: >-
+              Identification of the issuer of the proprietary
+              bank transaction code.
+            type: string
+            minLength: 1
+            maxLength: 35
+        required:
+          - Code
+        additionalProperties: false
+      CurrencyExchange:
+        description: Set of elements used to provide details on the currency exchange.
+        type: object
+        properties:
+          SourceCurrency:
+            description: >-
+              Currency from which an amount is to be converted in a currency
+              conversion.
+            type: string
+            pattern: "^[A-Z]{3,3}$"
+          TargetCurrency:
+            description: >-
+              Currency from which an amount is to be converted in a currency
+              conversion.
+            type: string
+            pattern: "^[A-Z]{3,3}$"
+          UnitCurrency:
+            description: >-
+              Currency from which an amount is to be converted in a currency
+              conversion.
+            type: string
+            pattern: "^[A-Z]{3,3}$"
+          ExchangeRate:
+            description: >-
+              Factor used to convert an amount from one currency into another. This
+              reflects the price at which one currency was bought with another
+              currency.
+
+              Usage: ExchangeRate expresses the ratio between UnitCurrency and
+              QuotedCurrency (ExchangeRate = UnitCurrency/QuotedCurrency).
+            type: number
+          ContractIdentification:
+            description: >-
+              Unique identification to unambiguously identify the foreign exchange
+              contract.
+            type: string
+            minLength: 1
+            maxLength: 35
+          QuotationDate:
+            description: >-
+              Date and time at which an exchange rate is quoted.
+
+              All dates in the JSON payloads are represented in ISO 8601 date-time
+              format.
+
+              All date-time fields in responses must include the timezone. An
+              example is below:
+
+              2017-04-05T10:43:07+00:00
+            type: string
+            format: date-time
+          InstructedAmount:
+            description: >-
+              Amount of money of the cash balance after a transaction entry is applied
+              to the account..
+            type: object
+            properties:
+              Amount:
+                description: >-
+                  A number of monetary units specified in an active currency where the unit
+                  of currency is explicit and compliant with ISO 4217.
+                type: string
+                pattern: '^\d{1,13}\.\d{1,5}$'
+              Currency:
+                description: >-
+                  A code allocated to a currency by a Maintenance Agency under an
+                  international identification scheme, as described in the latest
+                  edition of the international standard ISO 4217 "Codes for the
+                  representation of currencies and funds".
+                type: string
+                pattern: "^[A-Z]{3,3}$"
+            required:
+              - Amount
+              - Currency
+            additionalProperties: false
+        required:
+          - SourceCurrency
+          - ExchangeRate
+        additionalProperties: false
+      CreditorAgent:
+        type: object
+        properties:
+          SchemeName:
+            description: >-
+              Name of the identification scheme, in a coded form as published in
+              an external list.
+            type: string
+            enum:
+              - BICFI
+          Identification:
+            type: string
+            minLength: 1
+            maxLength: 35
+            description: >-
+              Unique and unambiguous identification of a financial institution
+              or a branch of a financial institution.
+        required:
+          - SchemeName
+          - Identification
+        additionalProperties: false
+        description: Financial institution servicing an account for the creditor.
+      DebtorAgent:
+        type: object
+        properties:
+          SchemeName:
+            description: >-
+              Name of the identification scheme, in a coded form as published in
+              an external list.
+            type: string
+            enum:
+              - BICFI
+          Identification:
+            type: string
+            minLength: 1
+            maxLength: 35
+            description: >-
+              Unique and unambiguous identification of a financial institution
+              or a branch of a financial institution.
+        required:
+          - SchemeName
+          - Identification
+        additionalProperties: false
+        description: Financial institution servicing an account for the debtor.
+      CardInstrument:
+        description: >-
+          Set of elements to describe the card instrument used in the
+          transaction.
+        type: object
+        properties:
+          CardSchemeName:
+            description: Name of the card scheme.
+            type: string
+            enum:
+              - AmericanExpress
+              - Diners
+              - Discover
+              - MasterCard
+              - VISA
+          AuthorisationType:
+            description: The card authorisation type.
+            type: string
+            enum:
+              - Contactless
+              - None
+              - PIN
+          Name:
+            description: Name of the cardholder using the card instrument.
+            type: string
+            minLength: 1
+            maxLength: 70
+          Identification:
+            description: >-
+              Identification assigned by an institution to identify the card
+              instrument used in the transaction. This identification is known
+              by the account owner, and may be masked.
+            type: string
+            minLength: 1
+            maxLength: 34
+        required:
+          - CardSchemeName
+        additionalProperties: false
+      TransactionInformation:
+        description: >-
+          Further details of the transaction. This is the
+          transaction narrative, which is unstructured text.
+        type: string
+        minLength: 1
+        maxLength: 500
+      Balance:
+        description: >-
+          Set of elements used to define the balance as a
+          numerical representation of the net increases and
+          decreases in an account after a transaction entry is
+          applied to the account.
+        type: object
+        properties:
+          Amount:
+            description: >-
+              Amount of money of the cash balance after a
+              transaction entry is applied to the account..
+            type: object
+            properties:
+              Amount:
+                type: string
+                pattern: '^\d{1,13}\.\d{1,5}$'
+              Currency:
+                description: >-
+                  A code allocated to a currency by a
+                  Maintenance Agency under an international
+                  identification scheme, as described in the
+                  latest edition of the international standard
+                  ISO 4217 'Codes for the representation of
+                  currencies and funds'
+                type: string
+                pattern: "^[A-Z]{3,3}$"
+            required:
+              - Amount
+              - Currency
+            additionalProperties: false
+          CreditDebitIndicator:
+            description: >-
+              Indicates whether the balance is a credit or a
+              debit balance. Usage: A zero balance is
+              considered to be a credit balance.
+            type: string
+            enum:
+              - Credit
+              - Debit
+          Type:
+            description: "Balance type, in a coded form."
+            type: string
+            enum:
+              - ClosingAvailable
+              - ClosingBooked
+              - Expected
+              - ForwardAvailable
+              - Information
+              - InterimAvailable
+              - InterimBooked
+              - OpeningAvailable
+              - OpeningBooked
+              - PreviouslyClosedBooked
+        required:
+          - Amount
+          - CreditDebitIndicator
+          - Type
+        additionalProperties: false
+      MerchantDetails:
+        description: Details of the merchant involved in the transaction.
+        type: object
+        properties:
+          MerchantName:
+            description: Name by which the merchant is known.
+            type: string
+            minLength: 1
+            maxLength: 350
+          MerchantCategoryCode:
+            description: >-
+              Category code conform to ISO 18245, related to
+              the type of services or goods the merchant
+              provides for the transaction.
+            type: string
+            minLength: 3
+            maxLength: 4
+        additionalProperties: false
+      CreditorAccount:
+        type: object
+        properties:
+          SchemeName:
+            $ref: "#/definitions/AccountSchemeModel"
+          Identification:
+            description: >-
+              Identification assigned by an institution to
+              identify an account. This identification is
+              known by the account owner.
+            type: string
+            minLength: 1
+            maxLength: 34
+          Name:
+            type: string
+            minLength: 1
+            maxLength: 70
+            description: >-
+              Name of the account, as assigned by the account servicing
+              institution, in agreement with the account owner in order to
+              provide an additional means of identification of the account.
+
+              Usage: The account name is different from the account owner name.
+              The account name is used in certain user communities to provide a
+              means of identifying the account, in addition to the account
+              owner's identity and the account number.
+          SecondaryIdentification:
+            type: string
+            minLength: 1
+            maxLength: 34
+            description: >-
+              This is secondary identification of the account, as assigned by
+              the account servicing institution.
+        required:
+          - SchemeName
+          - Identification
+        additionalProperties: false
+        description: >-
+          Unambiguous identification of the account of the creditor, in the case
+          of a debit transaction.
+      DebtorAccount:
+        type: object
+        properties:
+          SchemeName:
+            $ref: "#/definitions/AccountSchemeModel"
+          Identification:
+            description: >-
+              Identification assigned by an institution to
+              identify an account. This identification is
+              known by the account owner.
+            type: string
+            minLength: 1
+            maxLength: 34
+          Name:
+            type: string
+            minLength: 1
+            maxLength: 70
+            description: >-
+              Name of the account, as assigned by the account servicing
+              institution, in agreement with the account owner in order to
+              provide an additional means of identification of the account.
+
+              Usage: The account name is different from the account owner name.
+              The account name is used in certain user communities to provide a
+              means of identifying the account, in addition to the account
+              owner's identity and the account number.
+          SecondaryIdentification:
+            type: string
+            minLength: 1
+            maxLength: 34
+            description: >-
+              This is secondary identification of the account, as assigned by
+              the account servicing institution.
+        required:
+          - SchemeName
+          - Identification
+        additionalProperties: false
+        description: >-
+          Unambiguous identification of the account of the debtor, in the case
+          of a crebit transaction.
+    required:
+      - AccountId
+      - Amount
+      - CreditDebitIndicator
+      - Status
+      - BookingDateTime
+    additionalProperties: false
+  BeneficiaryModel:
+    type: object
+    properties:
+      AccountId:
+        description: >-
+          A unique and immutable identifier used to identify
+          the account resource. This identifier has no meaning
+          to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      BeneficiaryId:
+        description: >-
+          A unique and immutable identifier used to identify
+          the beneficiary resource. This identifier has no
+          meaning to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      Reference:
+        $ref: "#/definitions/BECSRemittance"
+      CreditorAgent:
+        description: >-
+          Party that manages the account on behalf of the account owner, that is
+          manages the registration and booking of entries on the account,
+          calculates balances on the account and provides information about the
+          account.
+
+          This is the servicer of the beneficiary account.
+        type: object
+        properties:
+          SchemeName:
+            description: >-
+              Name of the identification scheme, in a coded form as published in
+              an external list.
+            type: string
+            enum:
+              - BICFI
+          Identification:
+            description: >-
+              Unique and unambiguous identification of the servicing
+              institution.
+            type: string
+            minLength: 1
+            maxLength: 35
+          Name:
+            description: >-
+              Name by which an agent is known and which is usually used to
+              identify that agent.
+            type: string
+            minLength: 1
+            maxLength: 140
+          PostalAddress:
+            description: >-
+              Information that locates and identifies a specific address, as
+              defined by postal services.
+            type: object
+            properties:
+              AddressType:
+                description: Identifies the nature of the postal address.
+                type: string
+                enum:
+                  - Business
+                  - Correspondence
+                  - DeliveryTo
+                  - MailTo
+                  - POBox
+                  - Postal
+                  - Residential
+                  - Statement
+              AddressLine:
+                description: >-
+                  Information that locates and identifies a specific
+                  address, as defined by postal services, that is
+                  presented in free format text.
+                type: array
+                items:
+                  type: string
+                  minLength: 1
+                  maxLength: 70
+                minItems: 0
+                maxItems: 5
+              StreetName:
+                description: Name of a street or thoroughfare.
+                type: string
+                minLength: 1
+                maxLength: 70
+              BuildingNumber:
+                description: >-
+                  Number that identifies the position of a building on a street.
+                type: string
+                minLength: 1
+                maxLength: 16
+              PostCode:
+                description: >-
+                  Identifier consisting of a group of letters and/or numbers
+                  that is added to a postal address to assist the sorting of
+                  mail.
+                type: string
+                minLength: 1
+                maxLength: 16
+              TownName:
+                description: >-
+                  Name of a built-up area, with defined boundaries, and a local
+                  government.
+                type: string
+                minLength: 1
+                maxLength: 35
+              CountrySubDivision:
+                description: >-
+                  Identifies a subdivision of a country such as state, region,
+                  county.
+                type: string
+                minLength: 1
+                maxLength: 35
+              Country:
+                description: Nation with its own government.
+                type: string
+                pattern: "^[A-Z]{2,2}$"
+            required:
+              - Country
+            additionalProperties: false
+        additionalProperties: false
+      CreditorAccount:
+        description: >-
+          Provides the details to identify the beneficiary
+          account.
+        type: object
+        properties:
+          SchemeName:
+            $ref: "#/definitions/AccountSchemeModel"
+          Identification:
+            description: >-
+              Identification assigned by an institution to
+              identify an account. This identification is
+              known by the account owner.
+            type: string
+            minLength: 1
+            maxLength: 34
+          Name:
+            description: >-
+              Name of the account, as assigned by the account
+              servicing institution, in agreement with the
+              account owner in order to provide an additional
+              means of identification of the account. Usage:
+              The account name is different from the account
+              owner name. The account name is used in certain
+              user communities to provide a means of
+              identifying the account, in addition to the
+              account owner's identity and the account number.
+            type: string
+            minLength: 1
+            maxLength: 70
+          SecondaryIdentification:
+            description: >-
+              This is secondary identification of the account, as assigned by the
+              account servicing institution.
+            type: string
+            minLength: 1
+            maxLength: 34
+        required:
+          - SchemeName
+          - Identification
+        additionalProperties: false
+    required:
+      - AccountId
+    additionalProperties: false
+  StandingOrderModel:
+    type: object
+    properties:
+      AccountId:
+        description: >-
+          A unique and immutable identifier used to identify
+          the account resource. This identifier has no meaning
+          to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      StandingOrderId:
+        description: >-
+          A unique and immutable identifier used to identify
+          the standing order resource. This identifier has no
+          meaning to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      Frequency:
+        description: >
+          EvryDay - Every day
+
+          EvryWorkgDay - Every working day
+
+          IntrvlWkDay - An interval specified in weeks (01 to
+          09), and the day within the week (01 to 07)
+
+          WkInMnthDay - A monthly interval, specifying the
+          week of the month (01 to 05) and day within the week
+          (01 to 07)
+
+          IntrvlMnthDay - An interval specified in months
+          (between 01 to 06, 12, 24), specifying the day
+          within the month (-5 to -1, 1 to 31)
+
+
+          Patterns:
+
+          EvryDay (ScheduleCode)
+
+          EvryWorkgDay (ScheduleCode)
+
+          IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode
+          + IntervalInWeeks + DayInWeek)
+
+          WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode +
+          WeekInMonth + DayInWeek)
+
+          IntrvlMnthDay:IntervalInMonths:DayInMonth
+          (ScheduleCode + IntervalInMonths + DayInMonth)
+
+
+          The regular expression for this element combines
+          five smaller versions for each permitted pattern. To
+          aid legibility - the components are presented
+          individually here:
+
+          EvryDay
+
+          EvryWorkgDay
+
+          IntrvlWkDay:0[1-9]:0[1-7]
+
+          WkInMnthDay:0[1-5]:0[1-7]
+
+          IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01])
+
+        type: string
+        pattern: >-
+          ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$
+      Reference:
+        $ref: "#/definitions/BECSRemittance"
+      FirstPaymentDateTime:
+        description: >-
+          The date on which the first payment for a Standing
+          Order schedule will be made.
+
+          All dates in the JSON payloads are represented in
+          ISO 8601 date-time format.
+
+          All date-time fields in responses must include the
+          timezone. An example is below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      FirstPaymentAmount:
+        description: The amount of the first Standing Order
+        type: object
+        properties:
+          Amount:
+            type: string
+            pattern: '^\d{1,13}\.\d{1,5}$'
+          Currency:
+            description: >-
+              A code allocated to a currency by a Maintenance
+              Agency under an international identification
+              scheme, as described in the latest edition of
+              the international standard ISO 4217 'Codes for
+              the representation of currencies and funds'
+            type: string
+            pattern: "^[A-Z]{3,3}$"
+        required:
+          - Amount
+          - Currency
+        additionalProperties: false
+      NextPaymentDateTime:
+        description: >-
+          The date on which the next payment for a Standing
+          Order schedule will be made.
+
+          All dates in the JSON payloads are represented in
+          ISO 8601 date-time format.
+
+          All date-time fields in responses must include the
+          timezone. An example is below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      NextPaymentAmount:
+        description: The amount of the next Standing Order
+        type: object
+        properties:
+          Amount:
+            type: string
+            pattern: '^\d{1,13}\.\d{1,5}$'
+          Currency:
+            description: >-
+              A code allocated to a currency by a Maintenance
+              Agency under an international identification
+              scheme, as described in the latest edition of
+              the international standard ISO 4217 'Codes for
+              the representation of currencies and funds'
+            type: string
+            pattern: "^[A-Z]{3,3}$"
+        required:
+          - Amount
+          - Currency
+        additionalProperties: false
+      FinalPaymentDateTime:
+        description: >-
+          The date on which the final payment for a Standing
+          Order schedule will be made.
+
+          All dates in the JSON payloads are represented in
+          ISO 8601 date-time format.
+
+          All date-time fields in responses must include the
+          timezone. An example is below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      FinalPaymentAmount:
+        description: The amount of the final Standing Order
+        type: object
+        properties:
+          Amount:
+            type: string
+            pattern: '^\d{1,13}\.\d{1,5}$'
+          Currency:
+            description: >-
+              A code allocated to a currency by a Maintenance
+              Agency under an international identification
+              scheme, as described in the latest edition of
+              the international standard ISO 4217 'Codes for
+              the representation of currencies and funds'
+            type: string
+            pattern: "^[A-Z]{3,3}$"
+        required:
+          - Amount
+          - Currency
+        additionalProperties: false
+      StandingOrderStatusCode:
+        description: Specifies the status of the standing order in code form.
+        type: string
+        enum:
+          - Active
+          - Inactive
+      CreditorAgent:
+        description: >-
+          Party that manages the account on behalf of the
+          account owner, that is manages the registration and
+          booking of entries on the account, calculates
+          balances on the account and provides information
+          about the account. This is the servicer of the
+          beneficiary account
+        type: object
+        properties:
+          SchemeName:
+            description: >-
+              Name of the identification scheme, in a coded
+              form as published in an external list.
+            type: string
+            enum:
+              - BICFI
+          Identification:
+            description: >-
+              Unique and unambiguous identification of the
+              servicing institution.
+            type: string
+            minLength: 1
+            maxLength: 35
+        required:
+          - SchemeName
+          - Identification
+        additionalProperties: false
+      CreditorAccount:
+        description: >-
+          Provides the details to identify the beneficiary
+          account.
+        type: object
+        properties:
+          SchemeName:
+            $ref: "#/definitions/AccountSchemeModel"
+          Identification:
+            description: >-
+              Identification assigned by an institution to
+              identify an account. This identification is
+              known by the account owner.
+            type: string
+            minLength: 1
+            maxLength: 34
+          Name:
+            description: >-
+              Name of the account, as assigned by the account
+              servicing institution, in agreement with the
+              account owner in order to provide an additional
+              means of identification of the account. Usage:
+              The account name is different from the account
+              owner name. The account name is used in certain
+              user communities to provide a means of
+              identifying the account, in addition to the
+              account owner's identity and the account number.
+            type: string
+            minLength: 1
+            maxLength: 70
+          SecondaryIdentification:
+            description: >-
+              This is secondary identification of the account,
+              as assigned by the account servicing institution.
+            type: string
+            minLength: 1
+            maxLength: 34
+        required:
+          - SchemeName
+          - Identification
+        additionalProperties: false
+    required:
+      - AccountId
+      - Frequency
+      - NextPaymentDateTime
+      - NextPaymentAmount
+    additionalProperties: false
+  DirectDebitModel:
+    type: object
+    properties:
+      AccountId:
+        description: >-
+          A unique and immutable identifier used to identify
+          the account resource. This identifier has no meaning
+          to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      DirectDebitId:
+        description: >-
+          A unique and immutable identifier used to identify
+          the direct debit resource. This identifier has no
+          meaning to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      MandateIdentification:
+        description: >-
+          Direct Debit reference.
+        type: string
+        minLength: 1
+        maxLength: 35
+      DirectDebitStatusCode:
+        description: >-
+          Specifies the status of the direct debit in code
+          form.
+        type: string
+        enum:
+          - Active
+          - Inactive
+      Name:
+        description: Name of Service User
+        type: string
+        minLength: 1
+        maxLength: 70
+      PreviousPaymentDateTime:
+        description: >-
+          Date of most recent direct debit collection.
+
+          All dates in the JSON payloads are represented in
+          ISO 8601 date-time format.
+
+          All date-time fields in responses must include the
+          timezone. An example is below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      PreviousPaymentAmount:
+        description: >-
+          The amount of the most recent direct debit
+          collection.
+        type: object
+        properties:
+          Amount:
+            type: string
+            pattern: '^\d{1,13}\.\d{1,5}$'
+          Currency:
+            description: >-
+              A code allocated to a currency by a Maintenance
+              Agency under an international identification
+              scheme, as described in the latest edition of
+              the international standard ISO 4217 'Codes for
+              the representation of currencies and funds'
+            type: string
+            pattern: "^[A-Z]{3,3}$"
+        required:
+          - Amount
+          - Currency
+        additionalProperties: false
+    required:
+      - AccountId
+      - MandateIdentification
+      - Name
+    additionalProperties: false
+  OfferModel:
+    type: object
+    properties:
+      AccountId:
+        description: >-
+          A unique and immutable identifier used to identify
+          the account resource. This identifier has no meaning
+          to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      OfferId:
+        description: >-
+          A unique and immutable identifier used to identify the offer resource.
+          This identifier has no meaning to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      OfferType:
+        description: "Offer type, in a coded form."
+        type: string
+        enum:
+          - BalanceTransfer
+          - LimitIncrease
+          - MoneyTransfer
+          - Other
+          - PromotionalRate
+      Description:
+        description: Further details of the offer.
+        type: string
+        minLength: 1
+        maxLength: 500
+      StartDateTime:
+        description: >-
+          Date and time at which the offer starts.
+
+          All dates in the JSON payloads are represented in ISO 8601 date-time
+          format.
+
+          All date-time fields in responses must include the timezone. An
+          example is below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      EndDateTime:
+        description: >-
+          Date and time at which the offer ends.
+
+          All dates in the JSON payloads are represented in ISO 8601 date-time
+          format.
+
+          All date-time fields in responses must include the timezone. An
+          example is below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      Amount:
+        description: Amount of money associated with the offer type.
+        type: object
+        properties:
+          Amount:
+            type: string
+            pattern: '^\d{1,13}\.\d{1,5}$'
+          Currency:
+            description: >-
+              A code allocated to a currency by a Maintenance Agency under an
+              international identification scheme, as described in the latest
+              edition of the international standard ISO 4217 "Codes for the
+              representation of currencies and funds".
+            type: string
+            pattern: "^[A-Z]{3,3}$"
+        required:
+          - Amount
+          - Currency
+        additionalProperties: false
+      Fee:
+        description: Fee associated with the offer type.
+        type: object
+        properties:
+          Amount:
+            type: string
+            pattern: '^\d{1,13}\.\d{1,5}$'
+          Currency:
+            description: >-
+              A code allocated to a currency by a Maintenance Agency under an
+              international identification scheme, as described in the latest
+              edition of the international standard ISO 4217 "Codes for the
+              representation of currencies and funds".
+            type: string
+            pattern: "^[A-Z]{3,3}$"
+        required:
+          - Amount
+          - Currency
+        additionalProperties: false
+      Rate:
+        description: Rate associated with the offer type.
+        type: string
+        minLength: 1
+        maxLength: 10
+        pattern: '^(-?\d{1,3}){1}(\.\d{1,4}){0,1}$'
+      Value:
+        description: Value associated with the offer type.
+        type: integer
+        format: int32
+      Term:
+        description: Further details of the term of the offer.
+        type: string
+        minLength: 1
+        maxLength: 500
+      URL:
+        description: URL (Uniform Resource Locator) where the document can be found
+        type: string
+        minLength: 1
+        maxLength: 256
+    required:
+      - AccountId
+    additionalProperties: false
+  PartyModel:
+    type: object
+    properties:
+      PartyId:
+        description: >-
+          A unique and immutable identifier used to identify the customer
+          resource. This identifier has no meaning to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      PartyNumber:
+        description: Number assigned by an agent to identify its customer.
+        type: string
+        minLength: 1
+        maxLength: 35
+      PartyType:
+        description: "Party type, in a coded form."
+        type: string
+        enum:
+          - Delegate
+          - Joint
+          - Sole
+      Name:
+        description: >-
+          Name by which a party is known and which is usually used to identify
+          that party.
+        type: string
+        minLength: 1
+        maxLength: 70
+      EmailAddress:
+        description: Address for electronic mail (e-mail).
+        type: string
+        minLength: 1
+        maxLength: 256
+      Phone:
+        description: >-
+          Collection of information that identifies a phone number, as defined
+          by telecom services.
+        type: string
+        pattern: '\+[0-9]{1,3}-[0-9()+\-]{1,30}'
+      Mobile:
+        description: >-
+          Collection of information that identifies a mobile phone number, as
+          defined by telecom services.
+        type: string
+        pattern: '\+[0-9]{1,3}-[0-9()+\-]{1,30}'
+      Address:
+        type: array
+        description: Postal address of a party.
+        items:
+          description: Postal address of a party.
+          type: object
+          properties:
+            AddressType:
+              description: Identifies the nature of the postal address.
+              type: string
+              enum:
+                - Business
+                - Correspondence
+                - DeliveryTo
+                - MailTo
+                - POBox
+                - Postal
+                - Residential
+                - Statement
+            AddressLine:
+              description: >-
+                Information that locates and identifies a specific
+                address, as defined by postal services, that is
+                presented in free format text.
+              type: array
+              items:
+                type: string
+                minLength: 1
+                maxLength: 70
+              minItems: 0
+              maxItems: 5
+            StreetName:
+              description: >-
+                Name of a street or thoroughfare.
+              type: string
+              minLength: 1
+              maxLength: 70
+            BuildingNumber:
+              description: >-
+                Number that identifies the position of a building on a street.
+              type: string
+              minLength: 1
+              maxLength: 16
+            PostCode:
+              description: >-
+                Identifier consisting of a group of letters and/or numbers that is
+                added to a postal address to assist the sorting of mail.
+              type: string
+              minLength: 1
+              maxLength: 16
+            TownName:
+              description: >-
+                Name of a built-up area, with defined boundaries, and a local
+                government.
+              type: string
+              minLength: 1
+              maxLength: 35
+            CountrySubDivision:
+              description: >-
+                Identifies a subdivision of a country eg, state, region, county.
+              type: string
+              minLength: 1
+              maxLength: 35
+            Country:
+              description: >-
+                Nation with its own government, occupying a particular territory.
+              type: string
+              pattern: "^[A-Z]{2,2}$"
+          required:
+            - Country
+          additionalProperties: false
+    required:
+      - PartyId
+    additionalProperties: false
+  ScheduledPaymentModel:
+    type: object
+    properties:
+      AccountId:
+        description: >-
+          A unique and immutable identifier used to identify the account
+          resource. This identifier has no meaning to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      ScheduledPaymentId:
+        description: >-
+          A unique and immutable identifier used to identify the scheduled
+          payment resource. This identifier has no meaning to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      ScheduledPaymentDateTime:
+        description: >-
+          The date on which the scheduled payment will be made.
+
+          All dates in the JSON payloads are represented in ISO 8601 date-time
+          format.
+
+          All date-time fields in responses must include the timezone. An
+          example is below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      ScheduledType:
+        description: Specifies the scheduled payment date type requested
+        type: string
+        enum:
+          - Arrival
+          - Execution
+      InstructedAmount:
+        description: >-
+          Amount of money to be moved between the debtor and creditor, before
+          deduction of charges, expressed in the currency as ordered by the
+          initiating party.
+
+          Usage: This amount has to be transported unchanged through the
+          transaction chain.
+        type: object
+        properties:
+          Amount:
+            type: string
+            pattern: '^\d{1,13}\.\d{1,5}$'
+          Currency:
+            description: >-
+              A code allocated to a currency by a Maintenance Agency under an
+              international identification scheme, as described in the latest
+              edition of the international standard ISO 4217 "Codes for the
+              representation of currencies and funds".
+            type: string
+            pattern: "^[A-Z]{3,3}$"
+        required:
+          - Amount
+          - Currency
+        additionalProperties: false
+      Reference:
+        $ref: "#/definitions/BECSRemittance"
+      CreditorAgent:
+        type: object
+        properties:
+          SchemeName:
+            description: >-
+              Name of the identification scheme, in a coded form as published in
+              an external list.
+            type: string
+            enum:
+              - BICFI
+          Identification:
+            type: string
+            minLength: 1
+            maxLength: 35
+            description: >-
+              Unique and unambiguous identification of a financial institution
+              or a branch of a financial institution.
+        required:
+          - SchemeName
+          - Identification
+        additionalProperties: false
+        description: Financial institution servicing an account for the creditor.
+      CreditorAccount:
+        type: object
+        properties:
+          SchemeName:
+            $ref: "#/definitions/AccountSchemeModel"
+          Identification:
+            description: >-
+              Identification assigned by an institution to
+              identify an account. This identification is
+              known by the account owner.
+            type: string
+            minLength: 1
+            maxLength: 34
+          Name:
+            type: string
+            minLength: 1
+            maxLength: 70
+            description: >-
+              Name of the account, as assigned by the account servicing
+              institution, in agreement with the account owner in order to
+              provide an additional means of identification of the account.
+
+              Usage: The account name is different from the account owner name.
+              The account name is used in certain user communities to provide a
+              means of identifying the account, in addition to the account
+              owner's identity and the account number.
+          SecondaryIdentification:
+            type: string
+            minLength: 1
+            maxLength: 34
+            description: >-
+              This is secondary identification of the account, as assigned by
+              the account servicing institution.
+        required:
+          - SchemeName
+          - Identification
+        additionalProperties: false
+        description: Provides the details to identify the beneficiary account.
+    required:
+      - AccountId
+      - ScheduledPaymentDateTime
+      - ScheduledType
+      - InstructedAmount
+    additionalProperties: false
+  StatementModel:
+    description: Provides further details on a statement resource.
+    type: object
+    properties:
+      AccountId:
+        description: >-
+          A unique and immutable identifier used to identify the account
+          resource. This identifier has no meaning to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      StatementId:
+        description: >-
+          Unique identifier for the statement resource within an servicing
+          institution. This identifier is both unique and immutable.
+        type: string
+        minLength: 1
+        maxLength: 40
+      StatementReference:
+        description: >-
+          Unique reference for the statement. This reference may be optionally
+          populated if available.
+        type: string
+        minLength: 1
+        maxLength: 35
+      Type:
+        description: "Statement type, in a coded form."
+        type: string
+        enum:
+          - AccountClosure
+          - AccountOpening
+          - Annual
+          - Interim
+          - RegularPeriodic
+      StartDateTime:
+        description: >-
+          Date and time at which the statement period starts.
+
+          All dates in the JSON payloads are represented in ISO 8601 date-time
+          format.
+
+          All date-time fields in responses must include the timezone. An
+          example is below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      EndDateTime:
+        description: >-
+          Date and time at which the statement period ends.
+
+          All dates in the JSON payloads are represented in ISO 8601 date-time
+          format.
+
+          All date-time fields in responses must include the timezone. An
+          example is below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      CreationDateTime:
+        description: >-
+          Date and time at which the resource was created.
+
+          All dates in the JSON payloads are represented in ISO 8601 date-time
+          format.
+
+          All date-time fields in responses must include the timezone. An
+          example is below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      StatementDescription:
+        items:
+          description: >-
+            Other descriptions that may be available for the statement resource.
+          type: string
+          minLength: 1
+          maxLength: 500
+        type: array
+        description: >-
+          Other descriptions that may be available for the statement resource.
+      StatementBenefit:
+        type: array
+        description: >-
+          Set of elements used to provide details of a benefit or reward amount
+          for the statement resource.
+        items:
+          description: >-
+            Set of elements used to provide details of a benefit or reward
+            amount for the statement resource.
+          type: object
+          properties:
+            Amount:
+              description: Amount of money associated with the statement benefit type.
+              type: object
+              properties:
+                Amount:
+                  type: string
+                  pattern: '^\d{1,13}\.\d{1,5}$'
+                Currency:
+                  description: >-
+                    A code allocated to a currency by a Maintenance Agency under
+                    an international identification scheme, as described in the
+                    latest edition of the international standard ISO 4217 "Codes
+                    for the representation of currencies and funds".
+                  type: string
+                  pattern: "^[A-Z]{3,3}$"
+              required:
+                - Amount
+                - Currency
+              additionalProperties: false
+            Type:
+              description: "Benefit type, in a coded form."
+              type: string
+              enum:
+                - Cashback
+                - Insurance
+                - TravelDiscount
+                - TravelInsurance
+          required:
+            - Amount
+            - Type
+          additionalProperties: false
+      StatementFee:
+        type: array
+        description: >-
+          Set of elements used to provide details of a fee for the statement
+          resource.
+        items:
+          description: >-
+            Set of elements used to provide details of a fee for the statement
+            resource.
+          type: object
+          properties:
+            Amount:
+              description: Amount of money associated with the statement fee type.
+              type: object
+              properties:
+                Amount:
+                  type: string
+                  pattern: '^\d{1,13}\.\d{1,5}$'
+                Currency:
+                  description: >-
+                    A code allocated to a currency by a Maintenance Agency under
+                    an international identification scheme, as described in the
+                    latest edition of the international standard ISO 4217 "Codes
+                    for the representation of currencies and funds".
+                  type: string
+                  pattern: "^[A-Z]{3,3}$"
+              required:
+                - Amount
+                - Currency
+              additionalProperties: false
+            CreditDebitIndicator:
+              type: string
+              enum:
+                - Credit
+                - Debit
+              description: >-
+                Indicates whether the amount is a credit or a debit.
+                Usage: A zero amount is considered to be a credit amount.
+            Type:
+              description: "Fee type, in a coded form."
+              type: string
+              enum:
+                - Annual
+                - BalanceTransfer
+                - CashAdvance
+                - CashTransaction
+                - ForeignTransaction
+                - Gambling
+                - LatePayment
+                - MoneyTransfer
+                - Monthly
+                - Overlimit
+                - PostalOrder
+                - PrizeEntry
+                - StatementCopy
+                - Total
+          required:
+            - Amount
+            - CreditDebitIndicator
+            - Type
+          additionalProperties: false
+      StatementInterest:
+        type: array
+        description: >-
+          Set of elements used to provide details of a generic interest amount
+          related to the statement resource.
+        items:
+          description: >-
+            Set of elements used to provide details of a generic interest amount
+            related to the statement resource.
+          type: object
+          properties:
+            Amount:
+              description: >-
+                Amount of money associated with the statement interest amount
+                type.
+              type: object
+              properties:
+                Amount:
+                  type: string
+                  pattern: '^\d{1,13}\.\d{1,5}$'
+                Currency:
+                  description: >-
+                    A code allocated to a currency by a Maintenance Agency under
+                    an international identification scheme, as described in the
+                    latest edition of the international standard ISO 4217 "Codes
+                    for the representation of currencies and funds".
+                  type: string
+                  pattern: "^[A-Z]{3,3}$"
+              required:
+                - Amount
+                - Currency
+              additionalProperties: false
+            CreditDebitIndicator:
+              type: string
+              enum:
+                - Credit
+                - Debit
+              description: >-
+                Indicates whether the amount is a credit or a debit.
+                Usage: A zero amount is considered to be a credit amount.
+            Type:
+              description: "Interest amount type, in a coded form."
+              type: string
+              enum:
+                - BalanceTransfer
+                - Cash
+                - EstimatedNext
+                - Purchase
+                - Total
+          required:
+            - Amount
+            - CreditDebitIndicator
+            - Type
+          additionalProperties: false
+      StatementDateTime:
+        type: array
+        description: >-
+          Set of elements used to provide details of a generic date time for the
+          statement resource.
+        items:
+          description: >-
+            Set of elements used to provide details of a generic date time for
+            the statement resource.
+          type: object
+          properties:
+            DateTime:
+              description: >-
+                Date and time associated with the date time type.
+
+                All dates in the JSON payloads are represented in ISO 8601
+                date-time format.
+
+                All date-time fields in responses must include the timezone. An
+                example is below:
+
+                2017-04-05T10:43:07+00:00
+              type: string
+              format: date-time
+            Type:
+              description: "Date time type, in a coded form."
+              type: string
+              enum:
+                - BalanceTransferPromoEnd
+                - DirectDebitDue
+                - LastPayment
+                - LastStatement
+                - NextStatement
+                - PaymentDue
+                - PurchasePromoEnd
+                - StatementAvailable
+          required:
+            - DateTime
+            - Type
+          additionalProperties: false
+      StatementRate:
+        type: array
+        description: >-
+          Set of elements used to provide details of a generic rate related to
+          the statement resource.
+        items:
+          description: >-
+            Set of elements used to provide details of a generic rate related to
+            the statement resource.
+          type: object
+          properties:
+            Rate:
+              description: Rate associated with the statement rate type.
+              type: string
+              minLength: 1
+              maxLength: 10
+              pattern: '^(-?\d{1,3}){1}(\.\d{1,4}){0,1}$'
+            Type:
+              description: "Statement rate type, in a coded form."
+              type: string
+              enum:
+                - AnnualBalanceTransfer
+                - AnnualBalanceTransferAfterPromo
+                - AnnualBalanceTransferPromo
+                - AnnualCash
+                - AnnualPurchase
+                - AnnualPurchaseAfterPromo
+                - AnnualPurchasePromo
+                - MonthlyBalanceTransfer
+                - MonthlyCash
+                - MonthlyPurchase
+          required:
+            - Rate
+            - Type
+          additionalProperties: false
+      StatementValue:
+        type: array
+        description: >-
+          Set of elements used to provide details of a generic number value
+          related to the statement resource.
+        items:
+          description: >-
+            Set of elements used to provide details of a generic number value
+            related to the statement resource.
+          type: object
+          properties:
+            Value:
+              description: Value associated with the statement value type.
+              type: integer
+              format: int32
+            Type:
+              description: "Statement value type, in a coded form."
+              type: string
+              enum:
+                - AirMilesPoints
+                - AirMilesPointsBalance
+                - Credits
+                - Debits
+                - HotelPoints
+                - HotelPointsBalance
+                - RetailShoppingPoints
+                - RetailShoppingPointsBalance
+          required:
+            - Value
+            - Type
+          additionalProperties: false
+      StatementAmount:
+        type: array
+        description: >-
+          Set of elements used to provide details of a generic amount for the
+          statement resource.
+        items:
+          description: >-
+            Set of elements used to provide details of a generic amount for the
+            statement resource.
+          type: object
+          properties:
+            Amount:
+              description: Amount of money associated with the amount type.
+              type: object
+              properties:
+                Amount:
+                  type: string
+                  pattern: '^\d{1,13}\.\d{1,5}$'
+                Currency:
+                  description: >-
+                    A code allocated to a currency by a Maintenance Agency under
+                    an international identification scheme, as described in the
+                    latest edition of the international standard ISO 4217 "Codes
+                    for the representation of currencies and funds".
+                  type: string
+                  pattern: "^[A-Z]{3,3}$"
+              required:
+                - Amount
+                - Currency
+              additionalProperties: false
+            CreditDebitIndicator:
+              type: string
+              enum:
+                - Credit
+                - Debit
+              description: >-
+                Indicates whether the amount is a credit or a debit.
+                Usage: A zero amount is considered to be a credit amount.
+            Type:
+              description: "Amount type, in a coded form."
+              type: string
+              enum:
+                - ArrearsClosingBalance
+                - AvailableBalance
+                - AverageBalanceWhenInCredit
+                - AverageBalanceWhenInDebit
+                - AverageDailyBalance
+                - BalanceTransferClosingBalance
+                - CashClosingBalance
+                - ClosingBalance
+                - CreditLimit
+                - CurrentPayment
+                - DirectDebitPaymentDue
+                - MinimumPaymentDue
+                - PreviousClosingBalance
+                - PreviousPayment
+                - PurchaseClosingBalance
+                - StartingBalance
+                - TotalAdjustments
+                - TotalCashAdvances
+                - TotalCharges
+                - TotalCredits
+                - TotalDebits
+                - TotalPurchases
+          required:
+            - Amount
+            - CreditDebitIndicator
+            - Type
+          additionalProperties: false
+    required:
+      - AccountId
+      - Type
+      - StartDateTime
+      - EndDateTime
+      - CreationDateTime
+    additionalProperties: false
+  BECSRemittance:
+    type: object
+    description: >-
+      Unique reference, as assigned by the creditor, to
+      unambiguously refer to the payment transaction.
+      Usage: If available, the initiating party should
+      provide this reference in the structured remittance
+      information, to enable reconciliation by the
+      creditor upon receipt of the amount of money. If the
+      business context requires the use of a creditor
+      reference or a payment remit identification, and
+      only one identifier can be passed through the
+      end-to-end chain, the creditor's reference or
+      payment remittance identification should be quoted
+      in the end-to-end transaction identification.
+
+      NZ - Remittance information for use with BECS Electronic Credit payment scheme.
+      The Particulars, Code and Reference fields are currently constrained by
+      providers.  The design choice has been made not to constrain through schema
+      restrictions, to allow for future changes that remove the constraint.
+      Note that not all banks will accept all valid characters, in which case a
+      descriptive 400 Bad Request will be returned. Constraining to a-z, A-Z, -
+      (dash) and 0-9 is advised. One example is abc-XYZ-123
+    properties:
+      CreditorName:
+        type: string
+        maxLength: 20
+      CreditorReference:
+        type: object
+        properties:
+          Particulars:
+            type: string
+            maxLength: 12
+          Code:
+            type: string
+            maxLength: 12
+          Reference:
+            type: string
+            maxLength: 12
+        additionalProperties: false
+      DebtorName:
+        type: string
+        maxLength: 20
+      DebtorReference:
+        type: object
+        properties:
+          Particulars:
+            type: string
+            maxLength: 12
+          Code:
+            type: string
+            maxLength: 12
+          Reference:
+            type: string
+            maxLength: 12
+        additionalProperties: false
+    required:
+      - CreditorName
+    additionalProperties: false
+  Meta:
+    title: MetaData
+    type: object
+    description: Meta Data relevant to the payload
+    properties:
+      TotalPages:
+        type: integer
+        format: int32
+      FirstAvailableDateTime:
+        description: >-
+          All dates in the JSON payloads are represented in ISO 8601 date-time
+          format.
+
+          All date-time fields in responses must include the timezone. An example is
+          below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      LastAvailableDateTime:
+        description: >-
+          All dates in the JSON payloads are represented in ISO 8601 date-time
+          format.
+
+          All date-time fields in responses must include the timezone. An example is
+          below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+    additionalProperties: false
+securityDefinitions:
+  CustomerOAuth2Security:
+    type: oauth2
+    flow: accessCode
+    tokenUrl: "https://authserver.example/token"
+    authorizationUrl: "https://authserver.example/authorization"
+    scopes:
+      accounts: Ability to read accounts information
+    description: >-
+      OAuth flow, it is required when the Customer needs to perform SCA with the
+      API Provider when a Third Party wants to access an API Provider resource owned
+      by the Customer
+  ThirdPartyOAuth2Security:
+    type: oauth2
+    flow: application
+    tokenUrl: "https://authserver.example/token"
+    scopes:
+      accounts: Ability to read accounts information
+    description: >-
+      Third Party client credential authorisation flow with the API Provider
+responses:
+  400ErrorResponse:
+    description: Bad Request
+    headers:
+      x-fapi-interaction-id:
+        type: string
+        description: An RFC4122 UID used as a correlation id.
+    schema:
+      $ref: "#/definitions/ErrorResponse"
+  401ErrorResponse:
+    description: Unauthorized
+    headers:
+      x-fapi-interaction-id:
+        type: string
+        description: An RFC4122 UID used as a correlation id.
+  403ErrorResponse:
+    description: Forbidden
+    headers:
+      x-fapi-interaction-id:
+        type: string
+        description: An RFC4122 UID used as a correlation id.
+    schema:
+      $ref: "#/definitions/ErrorResponse"
+  405ErrorResponse:
+    description: Method Not Allowed
+    headers:
+      x-fapi-interaction-id:
+        type: string
+        description: An RFC4122 UID used as a correlation id.
+  406ErrorResponse:
+    description: Not Acceptable
+    headers:
+      x-fapi-interaction-id:
+        type: string
+        description: An RFC4122 UID used as a correlation id.
+  415ErrorResponse:
+    description: Unsupported Media Type
+    headers:
+      x-fapi-interaction-id:
+        type: string
+        description: An RFC4122 UID used as a correlation id.
+  429ErrorResponse:
+    description: Too Many Requests
+    headers:
+      Retry-After:
+        description: Number in seconds to wait
+        type: integer
+      x-fapi-interaction-id:
+        type: string
+        description: An RFC4122 UID used as a correlation id.
+  500ErrorResponse:
+    description: Internal Server Error
+    headers:
+      x-fapi-interaction-id:
+        type: string
+        description: An RFC4122 UID used as a correlation id.
+    schema:
+      $ref: "#/definitions/ErrorResponse"
+  501ErrorResponse:
+    description: Not Implemented
+    headers:
+      x-fapi-interaction-id:
+        type: string
+        description: An RFC4122 UID used as a correlation id.
+  503ErrorResponse:
+    description: Service Unavailable
+    headers:
+      x-fapi-interaction-id:
+        type: string
+        description: An RFC4122 UID used as a correlation id.
+    schema:
+      $ref: "#/definitions/ErrorResponse"

--- a/dist/v2.2.2/account-info-nz-swagger.yaml
+++ b/dist/v2.2.2/account-info-nz-swagger.yaml
@@ -12,7 +12,7 @@ info:
   license:
     name: Licence
     url: "https://www.apicentre.paymentsnz.co.nz/join/"
-  version: v2.2.1
+  version: v2.2.2
 basePath: /open-banking-nz/v2.2
 schemes:
   - https
@@ -42,7 +42,7 @@ tags:
       on a specific account
   - name: Offers
     description: >-
-      A set of elements that descirbe the list of offers avaialble to a specific
+      A set of elements that describe the list of offers available to a specific
       account
   - name: Party
     description: >-
@@ -2219,12 +2219,12 @@ definitions:
         type: object
         properties:
           Latitude:
-            description: Latitude measured in decimal degress
+            description: Latitude measured in decimal degrees
             type: string
             maxLength: 14
             pattern: '^-?\d{1,3}\.\d{1,8}$'
           Longitude:
-            description: Longitude measured in decimal degress
+            description: Longitude measured in decimal degrees
             type: string
             maxLength: 14
             pattern: '^-?\d{1,3}\.\d{1,8}$'
@@ -2965,7 +2965,7 @@ definitions:
         additionalProperties: false
         description: >-
           Unambiguous identification of the account of the debtor, in the case
-          of a crebit transaction.
+          of a credit transaction.
     required:
       - AccountId
       - Amount
@@ -4389,6 +4389,8 @@ responses:
       x-fapi-interaction-id:
         type: string
         description: An RFC4122 UID used as a correlation id.
+    schema:
+      $ref: "#/definitions/ErrorResponse"
   403ErrorResponse:
     description: Forbidden
     headers:
@@ -4403,18 +4405,24 @@ responses:
       x-fapi-interaction-id:
         type: string
         description: An RFC4122 UID used as a correlation id.
+    schema:
+      $ref: "#/definitions/ErrorResponse"
   406ErrorResponse:
     description: Not Acceptable
     headers:
       x-fapi-interaction-id:
         type: string
         description: An RFC4122 UID used as a correlation id.
+    schema:
+      $ref: "#/definitions/ErrorResponse"
   415ErrorResponse:
     description: Unsupported Media Type
     headers:
       x-fapi-interaction-id:
         type: string
         description: An RFC4122 UID used as a correlation id.
+    schema:
+      $ref: "#/definitions/ErrorResponse"
   429ErrorResponse:
     description: Too Many Requests
     headers:
@@ -4424,6 +4432,8 @@ responses:
       x-fapi-interaction-id:
         type: string
         description: An RFC4122 UID used as a correlation id.
+    schema:
+      $ref: "#/definitions/ErrorResponse"
   500ErrorResponse:
     description: Internal Server Error
     headers:
@@ -4438,6 +4448,8 @@ responses:
       x-fapi-interaction-id:
         type: string
         description: An RFC4122 UID used as a correlation id.
+    schema:
+      $ref: "#/definitions/ErrorResponse"
   503ErrorResponse:
     description: Service Unavailable
     headers:

--- a/dist/v2.3.2/Readme.md
+++ b/dist/v2.3.2/Readme.md
@@ -1,0 +1,7 @@
+# Account Information API
+
+## V2.3.1
+
+This is v2.3.1 NZ Open Banking Account Information API technical specification.
+
+The Swagger 2.0 document is [here](account-info-nz-swagger.yaml).

--- a/dist/v2.3.2/Readme.md
+++ b/dist/v2.3.2/Readme.md
@@ -1,7 +1,7 @@
 # Account Information API
 
-## V2.3.1
+## V2.3.2
 
-This is v2.3.1 NZ Open Banking Account Information API technical specification.
+This is v2.3.2 NZ Open Banking Account Information API technical specification.
 
 The Swagger 2.0 document is [here](account-info-nz-swagger.yaml).

--- a/dist/v2.3.2/account-info-nz-swagger.yaml
+++ b/dist/v2.3.2/account-info-nz-swagger.yaml
@@ -12,7 +12,7 @@ info:
   license:
     name: Licence
     url: "https://www.apicentre.paymentsnz.co.nz/join/"
-  version: v2.3.1
+  version: v2.3.2
 basePath: /open-banking-nz/v2.3
 schemes:
   - https
@@ -42,7 +42,7 @@ tags:
       on a specific account
   - name: Offers
     description: >-
-      A set of elements that descirbe the list of offers avaialble to a specific
+      A set of elements that describe the list of offers available to a specific
       account
   - name: Party
     description: >-
@@ -2219,12 +2219,12 @@ definitions:
         type: object
         properties:
           Latitude:
-            description: Latitude measured in decimal degress
+            description: Latitude measured in decimal degrees
             type: string
             maxLength: 14
             pattern: '^-?\d{1,3}\.\d{1,8}$'
           Longitude:
-            description: Longitude measured in decimal degress
+            description: Longitude measured in decimal degrees
             type: string
             maxLength: 14
             pattern: '^-?\d{1,3}\.\d{1,8}$'
@@ -2965,7 +2965,7 @@ definitions:
         additionalProperties: false
         description: >-
           Unambiguous identification of the account of the debtor, in the case
-          of a crebit transaction.
+          of a credit transaction.
     required:
       - AccountId
       - Amount
@@ -4389,6 +4389,8 @@ responses:
       x-fapi-interaction-id:
         type: string
         description: An RFC4122 UID used as a correlation id.
+    schema:
+      $ref: "#/definitions/ErrorResponse"
   403ErrorResponse:
     description: Forbidden
     headers:
@@ -4403,18 +4405,24 @@ responses:
       x-fapi-interaction-id:
         type: string
         description: An RFC4122 UID used as a correlation id.
+    schema:
+      $ref: "#/definitions/ErrorResponse"
   406ErrorResponse:
     description: Not Acceptable
     headers:
       x-fapi-interaction-id:
         type: string
         description: An RFC4122 UID used as a correlation id.
+    schema:
+      $ref: "#/definitions/ErrorResponse"
   415ErrorResponse:
     description: Unsupported Media Type
     headers:
       x-fapi-interaction-id:
         type: string
         description: An RFC4122 UID used as a correlation id.
+    schema:
+      $ref: "#/definitions/ErrorResponse"
   429ErrorResponse:
     description: Too Many Requests
     headers:
@@ -4424,6 +4432,8 @@ responses:
       x-fapi-interaction-id:
         type: string
         description: An RFC4122 UID used as a correlation id.
+    schema:
+      $ref: "#/definitions/ErrorResponse"
   500ErrorResponse:
     description: Internal Server Error
     headers:
@@ -4438,6 +4448,8 @@ responses:
       x-fapi-interaction-id:
         type: string
         description: An RFC4122 UID used as a correlation id.
+    schema:
+      $ref: "#/definitions/ErrorResponse"
   503ErrorResponse:
     description: Service Unavailable
     headers:

--- a/dist/v2.3.2/account-info-nz-swagger.yaml
+++ b/dist/v2.3.2/account-info-nz-swagger.yaml
@@ -1,0 +1,4448 @@
+swagger: "2.0"
+info:
+  title: Account and Transaction API Specification
+  description: >-
+    Swagger for Account and Transaction API Specification. This is heavily
+    derived from the Open Banking UK API - see www.openbanking.org.uk for
+    details.
+  termsOfService: "https://www.apicentre.paymentsnz.co.nz/contact-us/"
+  contact:
+    name: Payments NZ API Centre
+    email: apicentre@paymentsnz.co.nz
+  license:
+    name: Licence
+    url: "https://www.apicentre.paymentsnz.co.nz/join/"
+  version: v2.3.1
+basePath: /open-banking-nz/v2.3
+schemes:
+  - https
+consumes:
+  - application/json; charset=utf-8
+produces:
+  - application/json; charset=utf-8
+tags:
+  - name: Account Access Consents
+    description: >-
+      A consent to access account information resources
+  - name: Accounts
+    description: >-
+      A resource that represents the account to which credit and debit entries are
+      made
+  - name: Balances
+    description: >-
+      A resource that represents the net increases and decreases in an account at a
+      specific point in time
+  - name: Beneficiaries
+    description: >-
+      A set of elements that describe the list of trusted beneficiaries linked to a
+      specific account
+  - name: Direct Debits
+    description: >-
+      A set of elements that describe the list of direct-debits that have been set up
+      on a specific account
+  - name: Offers
+    description: >-
+      A set of elements that descirbe the list of offers avaialble to a specific
+      account
+  - name: Party
+    description: >-
+      A set of elements that describe the party linked to a specific account
+  - name: Scheduled Payments
+    description: >-
+      A set of elements that describe the list of scheduled-payments that have been
+      set up on a specific account
+  - name: Standing Orders
+    description: >-
+      A set of elements that describe the list of standing-orders that have been set
+      up on a specific account
+  - name: Statements
+    description: >-
+      A resource that describes summary details for an account statement period
+  - name: Transactions
+    description: >-
+      A resource that describes a posting to an account that results in an increase
+      or decrease to a balance
+paths:
+  "/account-access-consents":
+    post:
+      tags:
+        - Account Access Consents
+      operationId: CreateAccountAccessConsent
+      summary: Create an account access consent
+      description: >-
+        The account-access-consents resource represents a consent that has been
+        agreed between the Customer and the Third Party for the Third Party to
+        access a Customer's account information with an API Provider.
+      parameters:
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+        - name: body
+          in: body
+          description: Account Access Consent Body
+          required: true
+          schema:
+            title: Account Access Consent
+            type: object
+            properties:
+              Data:
+                $ref: "#/definitions/AccountAccessConsentModel"
+              Risk:
+                $ref: "#/definitions/Risk"
+            required:
+              - Data
+              - Risk
+            additionalProperties: false
+      responses:
+        "201":
+          description: Account Access Consent successfully created
+          schema:
+            title: Account Access Consent POST response
+            type: object
+            properties:
+              Data:
+                $ref: "#/definitions/AccountAccessConsentResponseModel"
+              Risk:
+                $ref: "#/definitions/Risk"
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Risk
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "415":
+          $ref: "#/responses/415ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - ThirdPartyOAuth2Security:
+            - accounts
+  "/account-access-consents/{ConsentId}":
+    get:
+      tags:
+        - Account Access Consents
+      operationId: GetAccountAccessConsent
+      summary: Get an account access consent
+      description: Retrieve an account access consent and check its status.
+      parameters:
+        - $ref: "#/parameters/ConsentIdParam"
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account Access Consent successfully retrieved
+          schema:
+            title: Account Access Consent GET response
+            type: object
+            properties:
+              Data:
+                $ref: "#/definitions/AccountAccessConsentResponseModel"
+              Risk:
+                $ref: "#/definitions/Risk"
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Risk
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - ThirdPartyOAuth2Security:
+            - accounts
+    delete:
+      tags:
+        - Account Access Consents
+      operationId: DeleteAccountAccessConsent
+      summary: Delete an account access consent
+      description: Delete an account access consent
+      parameters:
+        - $ref: "#/parameters/ConsentIdParam"
+        - $ref: "#/parameters/AuthorizationParam"
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+      responses:
+        "204":
+          description: Account Access Consent successfully deleted
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - ThirdPartyOAuth2Security:
+            - accounts
+  "/accounts":
+    get:
+      tags:
+        - Accounts
+      operationId: GetAccounts
+      summary: Get Accounts
+      description: Get a list of accounts
+      parameters:
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Accounts successfully retrieved
+          schema:
+            title: Account GET response
+            type: object
+            properties:
+              Data:
+                title: Data
+                type: object
+                description: Data
+                properties:
+                  Account:
+                    title: Account
+                    description: Account
+                    type: array
+                    items:
+                      $ref: "#/definitions/AccountModel"
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/accounts/{AccountId}":
+    get:
+      tags:
+        - Accounts
+      operationId: GetAccount
+      summary: Get Account
+      description: Get an account
+      parameters:
+        - $ref: "#/parameters/AccountIdParam"
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account resource successfully retrieved
+          schema:
+            title: Account GET response
+            type: object
+            properties:
+              Data:
+                title: Data
+                description: Data
+                type: object
+                properties:
+                  Account:
+                    $ref: "#/definitions/AccountModel"
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/accounts/{AccountId}/transactions":
+    get:
+      tags:
+        - Transactions
+      operationId: GetAccountTransactions
+      summary: Get Account Transactions
+      description: Get transactions related to an account
+      parameters:
+        - $ref: "#/parameters/AccountIdParam"
+        - $ref: "#/parameters/FromBookingDateTimeParam"
+        - $ref: "#/parameters/ToBookingDateTimeParam"
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account Transactions successfully retrieved
+          schema:
+            title: Transactions GET response
+            type: object
+            properties:
+              Data:
+                title: Data
+                description: Data
+                type: object
+                properties:
+                  Transaction:
+                    title: Transaction
+                    description: Transaction
+                    type: array
+                    items:
+                      $ref: "#/definitions/TransactionModel"
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/accounts/{AccountId}/beneficiaries":
+    get:
+      tags:
+        - Beneficiaries
+      operationId: GetAccountBeneficiaries
+      summary: Get Account Beneficiaries
+      description: Get Beneficiaries related to an account
+      parameters:
+        - $ref: "#/parameters/AccountIdParam"
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account Beneficiaries  successfully retrieved
+          schema:
+            title: Beneficiaries GET response
+            type: object
+            properties:
+              Data:
+                title: Data
+                description: Data
+                type: object
+                properties:
+                  Beneficiary:
+                    title: Beneficiary
+                    description: Beneficiary
+                    type: array
+                    items:
+                      $ref: "#/definitions/BeneficiaryModel"
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/accounts/{AccountId}/balances":
+    get:
+      tags:
+        - Balances
+      operationId: GetAccountBalances
+      summary: Get Account Balances
+      description: Get Balances related to an account
+      parameters:
+        - $ref: "#/parameters/AccountIdParam"
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account Balances successfully retrieved
+          schema:
+            title: Balances GET response
+            type: object
+            properties:
+              Data:
+                title: Data
+                description: Data
+                type: object
+                properties:
+                  Balance:
+                    title: Balance
+                    description: Balance
+                    type: array
+                    items:
+                      $ref: "#/definitions/BalanceModel"
+                required:
+                  - Balance
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/accounts/{AccountId}/direct-debits":
+    get:
+      tags:
+        - Direct Debits
+      operationId: GetAccountDirectDebits
+      summary: Get Account Direct Debits
+      description: Get Direct Debits related to an account
+      parameters:
+        - $ref: "#/parameters/AccountIdParam"
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account Direct Debits successfully retrieved
+          schema:
+            title: Direct Debit GET response
+            type: object
+            properties:
+              Data:
+                title: Data
+                description: Data
+                type: object
+                properties:
+                  DirectDebit:
+                    title: DirectDebit
+                    description: DirectDebit
+                    type: array
+                    items:
+                      $ref: "#/definitions/DirectDebitModel"
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/accounts/{AccountId}/standing-orders":
+    get:
+      tags:
+        - Standing Orders
+      operationId: GetAccountStandingOrders
+      summary: Get Account Standing Orders
+      description: Get Standing Orders related to an account
+      parameters:
+        - $ref: "#/parameters/AccountIdParam"
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account Standing Orders successfully retrieved
+          schema:
+            title: Standing Orders GET response
+            type: object
+            properties:
+              Data:
+                title: Data
+                description: Data
+                type: object
+                properties:
+                  StandingOrder:
+                    title: StandingOrder
+                    description: StandingOrder
+                    type: array
+                    items:
+                      $ref: "#/definitions/StandingOrderModel"
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/accounts/{AccountId}/offers":
+    get:
+      tags:
+        - Offers
+      operationId: GetAccountOffers
+      summary: Get Account Offers
+      description: Get Offers related to an account
+      parameters:
+        - $ref: "#/parameters/AccountIdParam"
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account Offers successfully retrieved
+          schema:
+            type: object
+            properties:
+              Data:
+                type: object
+                properties:
+                  Offer:
+                    items:
+                      $ref: "#/definitions/OfferModel"
+                    type: array
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/accounts/{AccountId}/party":
+    get:
+      tags:
+        - Party
+      operationId: GetAccountParty
+      summary: Get Account Party
+      description: Get Party related to an account
+      parameters:
+        - $ref: "#/parameters/AccountIdParam"
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account Party successfully retrieved
+          schema:
+            type: object
+            properties:
+              Data:
+                type: object
+                properties:
+                  Party:
+                    $ref: "#/definitions/PartyModel"
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/accounts/{AccountId}/scheduled-payments":
+    get:
+      tags:
+        - Scheduled Payments
+      operationId: GetAccountScheduledPayments
+      summary: Get Account Scheduled Payments
+      description: Get Scheduled Payments related to an account
+      parameters:
+        - $ref: "#/parameters/AccountIdParam"
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account Scheduled Payment successfully retrieved
+          schema:
+            type: object
+            properties:
+              Data:
+                type: object
+                properties:
+                  ScheduledPayment:
+                    items:
+                      $ref: "#/definitions/ScheduledPaymentModel"
+                    type: array
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/accounts/{AccountId}/statements":
+    get:
+      tags:
+        - Statements
+      operationId: GetAccountStatements
+      summary: Get Account Statements
+      description: Get Statements related to an account
+      parameters:
+        - $ref: "#/parameters/AccountIdParam"
+        - $ref: "#/parameters/FromStatementDateTimeParam"
+        - $ref: "#/parameters/ToStatementDateTimeParam"
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account Statement successfully retrieved
+          schema:
+            type: object
+            properties:
+              Data:
+                type: object
+                properties:
+                  Statement:
+                    items:
+                      $ref: "#/definitions/StatementModel"
+                    type: array
+                    description: Provides further details on a statement resource.
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/accounts/{AccountId}/statements/{StatementId}":
+    get:
+      tags:
+        - Statements
+      operationId: GetAccountStatement
+      summary: Get Statement
+      description: Get Statement related to an account
+      parameters:
+        - $ref: "#/parameters/AccountIdParam"
+        - $ref: "#/parameters/StatementIdParam"
+        - $ref: "#/parameters/FromStatementDateTimeParam"
+        - $ref: "#/parameters/ToStatementDateTimeParam"
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account Statement successfully retrieved
+          schema:
+            type: object
+            properties:
+              Data:
+                type: object
+                properties:
+                  Statement:
+                    $ref: "#/definitions/StatementModel"
+                    description: Provides further details on a statement resource.
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/accounts/{AccountId}/statements/{StatementId}/file":
+    get:
+      tags:
+        - Statements
+      operationId: GetAccountStatementFile
+      summary: Get Statement File
+      description: Get Statement related to an account
+      produces:
+        - "*/*"
+      parameters:
+        - $ref: "#/parameters/AccountIdParam"
+        - $ref: "#/parameters/StatementIdParam"
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account Statement File successfully retrieved
+          schema:
+            type: file
+            description: Statement File
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/accounts/{AccountId}/statements/{StatementId}/transactions":
+    get:
+      tags:
+        - Statements
+        - Transactions
+      operationId: GetAccountStatementTransactions
+      summary: Get Statement Transactions
+      description: Get Statement Transactions related to an account
+      parameters:
+        - $ref: "#/parameters/AccountIdParam"
+        - $ref: "#/parameters/StatementIdParam"
+        - $ref: "#/parameters/FromBookingDateTimeParam"
+        - $ref: "#/parameters/ToBookingDateTimeParam"
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account Transactions successfully retrieved
+          schema:
+            type: object
+            properties:
+              Data:
+                type: object
+                properties:
+                  Transaction:
+                    items:
+                      $ref: "#/definitions/TransactionModel"
+                    type: array
+                    description: Provides further details on an entry in the report.
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/standing-orders":
+    get:
+      tags:
+        - Standing Orders
+      operationId: GetStandingOrders
+      summary: Get Standing Orders
+      description: Get Standing Orders
+      parameters:
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Standing Orders successfully retrieved
+          schema:
+            title: Standing Orders GET response
+            type: object
+            properties:
+              Data:
+                title: Data
+                description: Data
+                type: object
+                properties:
+                  StandingOrder:
+                    title: StandingOrder
+                    description: StandingOrder
+                    type: array
+                    items:
+                      $ref: "#/definitions/StandingOrderModel"
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            additionalProperties: false
+            required:
+              - Data
+              - Links
+              - Meta
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/direct-debits":
+    get:
+      tags:
+        - Direct Debits
+      operationId: GetDirectDebits
+      summary: Get Direct Debits
+      description: Get Direct Debits
+      parameters:
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Direct Debits successfully retrieved
+          schema:
+            title: Direct Debit GET response
+            type: object
+            properties:
+              Data:
+                title: Data
+                description: Data
+                type: object
+                properties:
+                  DirectDebit:
+                    title: DirectDebit
+                    description: DirectDebit
+                    type: array
+                    items:
+                      $ref: "#/definitions/DirectDebitModel"
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/beneficiaries":
+    get:
+      tags:
+        - Beneficiaries
+      operationId: GetBeneficiaries
+      summary: Get Beneficiaries
+      description: Get Beneficiaries
+      parameters:
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Beneficiaries successfully retrieved
+          schema:
+            title: Beneficiaries GET response
+            type: object
+            properties:
+              Data:
+                title: Data
+                description: Data
+                type: object
+                properties:
+                  Beneficiary:
+                    title: Beneficiary
+                    description: Beneficiary
+                    type: array
+                    items:
+                      $ref: "#/definitions/BeneficiaryModel"
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/transactions":
+    get:
+      tags:
+        - Transactions
+      operationId: GetTransactions
+      summary: Get Transactions
+      description: Get Transactions
+      parameters:
+        - $ref: "#/parameters/FromBookingDateTimeParam"
+        - $ref: "#/parameters/ToBookingDateTimeParam"
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Transactions successfully retrieved
+          schema:
+            title: Transactions GET response
+            type: object
+            properties:
+              Data:
+                title: Data
+                description: Data
+                type: object
+                properties:
+                  Transaction:
+                    title: Transaction
+                    description: Transaction
+                    type: array
+                    items:
+                      $ref: "#/definitions/TransactionModel"
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/balances":
+    get:
+      tags:
+        - Balances
+      operationId: GetBalances
+      summary: Get Balances
+      description: Get Balances
+      parameters:
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Balances successfully retrieved
+          schema:
+            title: Balances GET response
+            type: object
+            properties:
+              Data:
+                title: Data
+                description: Data
+                type: object
+                properties:
+                  Balance:
+                    title: Balance
+                    description: Balance
+                    type: array
+                    items:
+                      $ref: "#/definitions/BalanceModel"
+                required:
+                  - Balance
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            additionalProperties: false
+            required:
+              - Data
+              - Links
+              - Meta
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/offers":
+    get:
+      tags:
+        - Offers
+      operationId: GetOffers
+      summary: Get Offers
+      description: Get Offers
+      parameters:
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account Offers successfully retrieved
+          schema:
+            type: object
+            properties:
+              Data:
+                type: object
+                properties:
+                  Offer:
+                    items:
+                      $ref: "#/definitions/OfferModel"
+                    type: array
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/party":
+    get:
+      tags:
+        - Party
+      operationId: GetParty
+      summary: Get Party
+      description: Get Party of logged in Customer
+      parameters:
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account Party successfully retrieved
+          schema:
+            type: object
+            properties:
+              Data:
+                type: object
+                properties:
+                  Party:
+                    $ref: "#/definitions/PartyModel"
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/scheduled-payments":
+    get:
+      tags:
+        - Scheduled Payments
+      operationId: GetScheduledPayments
+      summary: Get Scheduled Payments
+      description: Get Scheduled Payments
+      parameters:
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account Scheduled Payment successfully retrieved
+          schema:
+            type: object
+            properties:
+              Data:
+                type: object
+                properties:
+                  ScheduledPayment:
+                    items:
+                      $ref: "#/definitions/ScheduledPaymentModel"
+                    type: array
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+  "/statements":
+    get:
+      tags:
+        - Statements
+      summary: Get Statements
+      description: Get Statements
+      operationId: GetStatements
+      parameters:
+        - $ref: "#/parameters/FromStatementDateTimeParam"
+        - $ref: "#/parameters/ToStatementDateTimeParam"
+        - $ref: "#/parameters/x-fapi-auth-date-Param"
+        - $ref: "#/parameters/x-fapi-customer-ip-address-Param"
+        - $ref: "#/parameters/x-fapi-interaction-id-Param"
+        - $ref: "#/parameters/x-merchant-ip-address-Param"
+        - $ref: "#/parameters/x-customer-user-agent-Param"
+        - $ref: "#/parameters/AuthorizationParam"
+      responses:
+        "200":
+          description: Account Statement successfully retrieved
+          schema:
+            type: object
+            properties:
+              Data:
+                type: object
+                properties:
+                  Statement:
+                    items:
+                      $ref: "#/definitions/StatementModel"
+                    type: array
+                    description: Provides further details on a statement.
+                additionalProperties: false
+              Links:
+                $ref: "#/definitions/Links"
+              Meta:
+                $ref: "#/definitions/Meta"
+            required:
+              - Data
+              - Links
+              - Meta
+            additionalProperties: false
+          headers:
+            x-fapi-interaction-id:
+              type: string
+              description: An RFC4122 UID used as a correlation id.
+        "400":
+          $ref: "#/responses/400ErrorResponse"
+        "401":
+          $ref: "#/responses/401ErrorResponse"
+        "403":
+          $ref: "#/responses/403ErrorResponse"
+        "405":
+          $ref: "#/responses/405ErrorResponse"
+        "406":
+          $ref: "#/responses/406ErrorResponse"
+        "429":
+          $ref: "#/responses/429ErrorResponse"
+        "500":
+          $ref: "#/responses/500ErrorResponse"
+        "501":
+          $ref: "#/responses/501ErrorResponse"
+        "503":
+          $ref: "#/responses/503ErrorResponse"
+      security:
+        - CustomerOAuth2Security:
+            - accounts
+parameters:
+  AccountIdParam:
+    name: AccountId
+    in: path
+    description: A unique identifier used to identify the account resource.
+    required: true
+    type: string
+  ConsentIdParam:
+    name: ConsentId
+    in: path
+    description: >-
+      Unique identification as assigned by the API Provider to uniquely identify the
+      account access consent.
+    required: true
+    type: string
+  FromBookingDateTimeParam:
+    in: query
+    name: fromBookingDateTime
+    type: string
+    format: date-time
+    description: >-
+      The UTC ISO 8601 Date Time to filter transactions FROM
+      NB Time component is optional - set to 00:00:00 for just Date.
+      If the Date Time contains a timezone, the API Provider must ignore the timezone
+      component.
+  StatementIdParam:
+    name: StatementId
+    in: path
+    description: A unique identifier used to identify the statement resource.
+    required: true
+    type: string
+  ToBookingDateTimeParam:
+    in: query
+    name: toBookingDateTime
+    type: string
+    format: date-time
+    description: >-
+      The UTC ISO 8601 Date Time to filter transactions TO
+      NB Time component is optional - set to 00:00:00 for just Date.
+      If the Date Time contains a timezone, the API Provider must ignore the timezone
+      component.
+  FromStatementDateTimeParam:
+    in: query
+    name: fromStatementDateTime
+    type: string
+    format: date-time
+    description: >-
+      The UTC ISO 8601 Date Time to filter statements FROM
+      NB Time component is optional - set to 00:00:00 for just Date.
+      If the Date Time contains a timezone, the API Provider must ignore the timezone
+      component.
+  ToStatementDateTimeParam:
+    in: query
+    name: toStatementDateTime
+    type: string
+    format: date-time
+    description: >-
+      The UTC ISO 8601 Date Time to filter statements TO
+      NB Time component is optional - set to 00:00:00 for just Date.
+      If the Date Time contains a timezone, the API Provider must ignore the timezone
+      component.
+  x-fapi-customer-ip-address-Param:
+    in: header
+    name: x-fapi-customer-ip-address
+    type: string
+    required: false
+    description: The Customer's IP address if the Customer is currently logged in with the Third Party.
+    pattern: ^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$
+  x-fapi-interaction-id-Param:
+    in: header
+    name: x-fapi-interaction-id
+    type: string
+    required: false
+    description: An RFC4122 UID used as a correlation id.
+  x-fapi-auth-date-Param:
+    in: header
+    name: x-fapi-auth-date
+    type: string
+    required: false
+    description: >-
+      The time when the Customer last logged in with the Third Party.
+
+      All dates in the HTTP headers are represented as RFC 7231 Full Dates. An
+      example is below:
+
+      Sun, 10 Sep 2017 19:43:31 UTC
+    pattern: >-
+      ^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), \d{2}
+      (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{4} \d{2}:\d{2}:\d{2}
+      (GMT|UTC)$
+  x-merchant-ip-address-Param:
+    in: header
+    name: x-merchant-ip-address
+    type: string
+    required: false
+    description: >-
+      The IP address of the merchant when making account information requests through a
+      Third Party.
+    pattern: ^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$
+  x-customer-user-agent-Param:
+    in: header
+    name: x-customer-user-agent
+    type: string
+    required: false
+    description: >-
+      The User-Agent of the application on the customer device that is used to
+      make the account information request
+  AuthorizationParam:
+    in: header
+    name: Authorization
+    type: string
+    required: true
+    description: "An Authorisation Token as per https://tools.ietf.org/html/rfc6750"
+definitions:
+  Error:
+    type: object
+    properties:
+      ErrorCode:
+        description: >-
+          Low level textual error code.
+        type: string
+        enum:
+          - Field.Expected
+          - Field.Invalid
+          - Field.Missing
+          - Field.Unexpected
+          - Header.Invalid
+          - Header.Missing
+          - QueryParam.Invalid
+          - Reauthenticate
+          - Reauthorise
+          - Resource.Consent.CreditorAccount
+          - Resource.Consent.DebtorAccount
+          - Resource.Consent.Exceed.DataPermissions
+          - Resource.Consent.Exceed.Dates
+          - Resource.Consent.Exceed.Frequency
+          - Resource.Consent.Exceed.MaximumAmount
+          - Resource.Consent.Exceed.TotalAmount
+          - Resource.Consent.Exceed.TotalCount
+          - Resource.Consent.Exceed.TransactionDates
+          - Resource.Consent.InvalidStatus
+          - Resource.Consent.Mismatch
+          - Resource.Invalid
+          - UnexpectedError
+          - Unsupported.AccountIdentifier
+          - Unsupported.AccountSecondaryIdentifier
+          - Unsupported.Currency
+          - Unsupported.Scheme
+      Message:
+        description: >-
+          A free text description of the error that occurred. E.g.,
+          'A mandatory field isn't supplied'.
+        type: string
+        minLength: 1
+        maxLength: 500
+      Path:
+        description: >-
+          A recommended but optional reference to the JSON Path of the field
+          with error, e.g., Data.Consent.InstructedAmount.Currency
+        type: string
+        minLength: 1
+        maxLength: 500
+      Url:
+        description: >-
+          URL to help remediate the problem, provide more information or to
+          API Reference.
+        type: string
+    required:
+      - ErrorCode
+      - Message
+    additionalProperties: false
+    minProperties: 1
+  ErrorResponse:
+    description: >-
+      An array of detail error codes, and messages, and URLs to documentation to
+      help remediation.
+    type: object
+    properties:
+      Code:
+        description: >-
+          High level textual error code to help categorise the errors.
+        type: string
+        minLength: 1
+        maxLength: 128
+      Id:
+        description: >-
+          A unique reference for the error instance, for audit purposes, in
+          case of unknown/unclassified errors.
+        type: string
+        minLength: 1
+        maxLength: 128
+      Message:
+        description: >-
+          Brief Error message. E.g., 'There is something wrong with the request
+          parameters provided'
+        type: string
+        minLength: 1
+        maxLength: 500
+      Errors:
+        items:
+          $ref: "#/definitions/Error"
+        type: array
+        minItems: 1
+    required:
+      - Code
+      - Message
+      - Errors
+    additionalProperties: false
+  BalanceModel:
+    type: object
+    description: Balance object schema
+    properties:
+      AccountId:
+        description: >-
+          A unique and immutable identifier used to identify the account
+          resource. This identifier has no meaning to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      Amount:
+        description: Amount of money of the cash balance.
+        type: object
+        properties:
+          Amount:
+            type: string
+            pattern: '^\d{1,13}\.\d{1,5}$'
+          Currency:
+            description: >-
+              A code allocated to a currency by a Maintenance Agency under an
+              international identification scheme, as described in the latest
+              edition of the international standard ISO 4217 'Codes for the
+              representation of currencies and funds'
+            type: string
+            pattern: "^[A-Z]{3,3}$"
+        required:
+          - Amount
+          - Currency
+        additionalProperties: false
+      CreditDebitIndicator:
+        description: >-
+          Indicates whether the balance is a credit or a debit balance. Usage: A
+          zero balance is considered to be a credit balance.
+        type: string
+        enum:
+          - Credit
+          - Debit
+      Type:
+        description: "Balance type, in a coded form."
+        type: string
+        enum:
+          - ClosingAvailable
+          - ClosingBooked
+          - Expected
+          - ForwardAvailable
+          - Information
+          - InterimAvailable
+          - InterimBooked
+          - OpeningAvailable
+          - OpeningBooked
+          - PreviouslyClosedBooked
+      DateTime:
+        description: >-
+          Indicates the date (and time) of the balance.
+
+          All dates in the JSON payloads are represented in ISO 8601 date-time
+          format.
+
+          All date-time fields in responses must include the timezone. An
+          example is below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      CreditLine:
+        type: array
+        items:
+          type: object
+          properties:
+            Included:
+              description: >-
+                Indicates whether or not the credit line is included in the
+                balance of the account. Usage: If not present, credit line is
+                not included in the balance amount of the account.
+              type: boolean
+            Amount:
+              description: Active Or Historic Currency Code and Amount
+              type: object
+              properties:
+                Amount:
+                  type: string
+                  pattern: '^\d{1,13}\.\d{1,5}$'
+                Currency:
+                  description: >-
+                    A code allocated to a currency by a Maintenance Agency under
+                    an international identification scheme, as described in the
+                    latest edition of the international standard ISO 4217 'Codes
+                    for the representation of currencies and funds'
+                  type: string
+                  pattern: "^[A-Z]{3,3}$"
+              required:
+                - Amount
+                - Currency
+              additionalProperties: false
+            Type:
+              description: "Limit type, in a coded form."
+              type: string
+              enum:
+                - Pre-Agreed
+                - Emergency
+                - Temporary
+              additionalProperties: false
+          required:
+            - Included
+          additionalProperties: false
+    required:
+      - AccountId
+      - Amount
+      - CreditDebitIndicator
+      - DateTime
+      - Type
+    minItems: 1
+    additionalProperties: false
+  AccountModel:
+    type: object
+    properties:
+      AccountId:
+        description: >-
+          A unique and immutable identifier used to identify the account
+          resource. This identifier has no meaning to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      Currency:
+        description: >-
+          Identification of the currency in which the account is held.  Usage:
+          Currency should only be used in case one and the same account number
+          covers several currencies and the initiating party needs to identify
+          which currency needs to be used for settlement on the account.
+        type: string
+        pattern: "^[A-Z]{3,3}$"
+      AccountType:
+        description: Specifies the type of account (personal or business).
+        type: string
+        enum:
+          - Business
+          - Personal
+      AccountSubType:
+        description: Specifies the sub type of account (product family group).
+        type: string
+        enum:
+          - ChargeCard
+          - CreditCard
+          - CurrentAccount
+          - EMoney
+          - Loan
+          - Mortgage
+          - PrePaidCard
+          - Savings
+      Description:
+        description: Specifies the description of the account type.
+        type: string
+        minLength: 1
+        maxLength: 35
+      Nickname:
+        description: >-
+          The nickname of the account, assigned by the account owner in order to
+          provide an additional means of identification of the account.
+        type: string
+        minLength: 1
+        maxLength: 70
+      Account:
+        description: Provides the details to identify an account.
+        type: object
+        properties:
+          SchemeName:
+            $ref: "#/definitions/AccountSchemeModel"
+          Identification:
+            description: >-
+              Identification assigned by an institution to
+              identify an account. This identification is
+              known by the account owner.
+            type: string
+            minLength: 1
+            maxLength: 34
+          Name:
+            description: >-
+              Name of the account, as assigned by the account servicing
+              institution, in agreement with the account owner in order to
+              provide an additional means of identification of the account.
+              Usage: The account name is different from the account owner name.
+              The account name is used in certain user communities to provide a
+              means of identifying the account, in addition to the account
+              owner's identity and the account number.
+            type: string
+            minLength: 1
+            maxLength: 70
+          SecondaryIdentification:
+            description: >-
+              This is secondary identification of the account, as assigned by
+              the account servicing institution.
+            type: string
+            minLength: 1
+            maxLength: 34
+        required:
+          - SchemeName
+          - Identification
+        additionalProperties: false
+      Servicer:
+        description: >-
+          Party that manages the account on behalf of the account owner, that is
+          manages the registration and booking of entries on the account,
+          calculates balances on the account and provides information about the
+          account.
+        type: object
+        properties:
+          SchemeName:
+            description: >-
+              Name of the identification scheme, in a coded form as published in
+              an external list.
+            type: string
+            enum:
+              - BICFI
+          Identification:
+            description: >-
+              Unique and unambiguous identification of the servicing
+              institution.
+            type: string
+            minLength: 1
+            maxLength: 35
+        required:
+          - SchemeName
+          - Identification
+        additionalProperties: false
+    additionalProperties: false
+    required:
+      - AccountId
+      - Currency
+      - Nickname
+  AccountSchemeModel:
+    type: string
+    enum:
+      - BECSElectronicCredit
+      - MaskedCardNumber
+  Links:
+    title: Links
+    type: object
+    description: Links relevant to the payload
+    properties:
+      Self:
+        type: string
+        format: uri
+      First:
+        type: string
+        format: uri
+      Prev:
+        type: string
+        format: uri
+      Next:
+        type: string
+        format: uri
+      Last:
+        type: string
+        format: uri
+    required:
+      - Self
+  Risk:
+    type: object
+    description: >-
+      The Risk section is sent by the initiating party to the API Provider.
+      It is used to specify additional details for risk scoring.
+    properties:
+      GeoLocation:
+        description: >-
+          Location of the end-user on the earth specified by two numbers
+          representing vertical and horizontal position
+        type: object
+        properties:
+          Latitude:
+            description: Latitude measured in decimal degress
+            type: string
+            maxLength: 14
+            pattern: '^-?\d{1,3}\.\d{1,8}$'
+          Longitude:
+            description: Longitude measured in decimal degress
+            type: string
+            maxLength: 14
+            pattern: '^-?\d{1,3}\.\d{1,8}$'
+      PaymentContextCode:
+        description: Specifies the payment context
+        title: PaymentContextCode
+        type: string
+        enum:
+          - BillPayment
+          - EcommerceGoods
+          - EcommerceServices
+          - Other
+          - PersonToPerson
+      MerchantCategoryCode:
+        description: >-
+          Category code conforms to ISO 18245, related to the type of services
+          or goods the merchant provides for the transaction
+        type: string
+        minLength: 3
+        maxLength: 4
+      MerchantCustomerIdentification:
+        description: The unique customer identifier of the Customer with the merchant.
+        type: string
+        minLength: 1
+        maxLength: 70
+      DeliveryAddress:
+        description: >-
+          Information that locates and identifies a specific
+          address, as defined by postal services or in free format
+          text.
+        type: object
+        properties:
+          AddressType:
+            description: >-
+              Identifies the nature of the postal address.
+            type: string
+            enum:
+              - DeliveryTo
+          AddressLine:
+            description: >-
+              Information that locates and identifies a specific
+              address, as defined by postal services, that is
+              presented in free format text.
+            type: array
+            items:
+              type: string
+              minLength: 1
+              maxLength: 70
+            minItems: 0
+            maxItems: 5
+          StreetName:
+            description: >-
+              Name of a street or thoroughfare.
+            type: string
+            minLength: 1
+            maxLength: 70
+          BuildingNumber:
+            description: >-
+              Number that identifies the position of a building on a
+              street.
+            type: string
+            minLength: 1
+            maxLength: 16
+          PostCode:
+            description: >-
+              Identifier consisting of a group of letters and/or
+              numbers that is added to a postal address to assist
+              the sorting of mail
+            type: string
+            minLength: 1
+            maxLength: 16
+          TownName:
+            description: >-
+              Name of a built-up area, with defined boundaries, and
+              a local government.
+            type: string
+            minLength: 1
+            maxLength: 35
+          CountrySubDivision:
+            description: >-
+              Identifies a subdivision of a country, for instance
+              state, region, county.
+            type: string
+            minLength: 1
+            maxLength: 35
+          Country:
+            description: >-
+              Nation with its own government, occupying a particular
+              territory.
+            type: string
+            pattern: "^[A-Z]{2,2}$"
+        required:
+          - Country
+        additionalProperties: false
+      EndUserAppName:
+        description: Name of the end user facing application
+        type: string
+        minLength: 1
+        maxLength: 70
+      EndUserAppVersion:
+        description: Version of the end user facing application
+        type: string
+        minLength: 1
+        maxLength: 14
+      MerchantName:
+        description: Name of the merchant
+        type: string
+        minLength: 1
+        maxLength: 70
+      MerchantNZBN:
+        description: NZ business number for the merchant
+        type: string
+        minLength: 1
+        maxLength: 70
+    additionalProperties: false
+  AccountAccessConsentModel:
+    type: object
+    properties:
+      Consent:
+        description: >-
+          Contains the requested consent
+        type: object
+        properties:
+          Permissions:
+            description: >-
+              Specifies the Open Banking account access consent types. This is a
+              list of the data clusters being consented by the Customer, and requested
+              for authorisation with the API Provider.
+            type: array
+            items:
+              description: >-
+                Specifies the Open Banking account access consent types. This is a
+                list of the data clusters being consented by the Customer, and
+                requested for authorisation with the API Provider.
+              type: string
+              enum:
+                - ReadAccountsBasic
+                - ReadAccountsDetail
+                - ReadBalances
+                - ReadBeneficiariesBasic
+                - ReadBeneficiariesDetail
+                - ReadDirectDebits
+                - ReadOffers
+                - ReadParty
+                - ReadPartyAuthUser
+                - ReadScheduledPaymentsBasic
+                - ReadScheduledPaymentsDetail
+                - ReadStandingOrdersBasic
+                - ReadStandingOrdersDetail
+                - ReadStatementsBasic
+                - ReadStatementsDetail
+                - ReadTransactionsBasic
+                - ReadTransactionsCredits
+                - ReadTransactionsDebits
+                - ReadTransactionsDetail
+              minProperties: 1
+              additionalProperties: false
+          ExpirationDateTime:
+            description: >-
+              Specified date and time the permissions will expire. If this is not
+              populated, the permissions will be open ended.
+
+              All dates in the JSON payloads are represented in ISO 8601 date-time
+              format.
+
+              All date-time fields in responses must include the timezone. An
+              example is below:
+
+              2017-04-05T10:43:07+00:00
+            type: string
+            format: date-time
+          TransactionFromDateTime:
+            description: >-
+              Specified start date and time for the transaction query period. If
+              this is not populated, the start date will be open ended, and data
+              will be returned from the earliest available transaction.
+
+              All dates in the JSON payloads are represented in ISO 8601 date-time
+              format.
+
+              All date-time fields in responses must include the timezone. An
+              example is below:
+
+              2017-04-05T10:43:07+00:00
+            type: string
+            format: date-time
+          TransactionToDateTime:
+            description: >-
+              Specified end date and time for the transaction query period. If this
+              is not populated, the end date will be open ended, and data will be
+              returned to the latest available transaction.
+
+              All dates in the JSON payloads are represented in ISO 8601 date-time
+              format.
+
+              All date-time fields in responses must include the timezone. An
+              example is below:
+
+              2017-04-05T10:43:07+00:00
+            type: string
+            format: date-time
+        required:
+          - Permissions
+        additionalProperties: false
+    additionalProperties: false
+    required:
+      - Consent
+  AccountAccessConsentResponseModel:
+    type: object
+    allOf:
+      - properties:
+          ConsentId:
+            description: >-
+              Unique identification as assigned to identify the account access consent.
+            type: string
+            minLength: 1
+            maxLength: 128
+          Status:
+            description: Specifies the status of the account access consent.
+            type: string
+            enum:
+              - Authorised
+              - AwaitingAuthorisation
+              - Rejected
+              - Revoked
+          CreationDateTime:
+            description: >-
+              Date and time at which the consent was created.
+
+              All dates in the JSON payloads are represented in ISO 8601
+              date-time format.
+
+              All date-time fields in responses must include the timezone. An
+              example is below:
+
+              2017-04-05T10:43:07+00:00
+            type: string
+            format: date-time
+          StatusUpdateDateTime:
+            description: >-
+              Date and time at which the consent status was updated.
+
+              All dates in the JSON payloads are represented in ISO 8601 date-time
+              format.
+
+              All date-time fields in responses must include the timezone. An
+              example is below:
+
+              2017-04-05T10:43:07+00:00
+            type: string
+            format: date-time
+        required:
+          - ConsentId
+          - Status
+          - CreationDateTime
+          - StatusUpdateDateTime
+        additionalProperties: false
+      - $ref: "#/definitions/AccountAccessConsentModel"
+  TransactionModel:
+    type: object
+    properties:
+      AccountId:
+        description: >-
+          A unique and immutable identifier used to identify
+          the account resource. This identifier has no meaning
+          to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      TransactionId:
+        description: >-
+          Unique identifier for the transaction within an
+          servicing institution. This identifier is both
+          unique and immutable.
+        type: string
+        minLength: 1
+        maxLength: 40
+      TransactionReference:
+        $ref: "#/definitions/BECSRemittance"
+      StatementReference:
+        type: array
+        items:
+          description: >-
+            Unique reference for the statement. This reference may be optionally
+            populated if available.
+          type: string
+          minLength: 1
+          maxLength: 35
+        description: >-
+          Unique reference for the statement. This reference may be optionally
+          populated if available.
+      Amount:
+        description: Amount of money in the cash entry.
+        type: object
+        properties:
+          Amount:
+            type: string
+            pattern: '^\d{1,13}\.\d{1,5}$'
+          Currency:
+            description: >-
+              A code allocated to a currency by a Maintenance
+              Agency under an international identification
+              scheme, as described in the latest edition of
+              the international standard ISO 4217 'Codes for
+              the representation of currencies and funds'
+            type: string
+            pattern: "^[A-Z]{3,3}$"
+        required:
+          - Amount
+          - Currency
+        additionalProperties: false
+      CreditDebitIndicator:
+        description: >-
+          Indicates whether the transaction is a credit or a
+          debit entry.
+        type: string
+        enum:
+          - Credit
+          - Debit
+      Status:
+        description: >-
+          Status of a transaction entry on the books of the
+          account servicer.
+        type: string
+        enum:
+          - Booked
+          - Pending
+      BookingDateTime:
+        description: >-
+          Date and time when a transaction entry is posted to
+          an account on the account servicer's books. Usage:
+          Booking date is the expected booking date, unless
+          the status is booked, in which case it is the actual
+          booking date.
+
+          All dates in the JSON payloads are represented in
+          ISO 8601 date-time format.
+
+          All date-time fields in responses must include the
+          timezone. An example is below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      ValueDateTime:
+        description: >-
+          Date and time at which assets become available to
+          the account owner in case of a credit entry, or
+          cease to be available to the account owner in case
+          of a debit entry.  Usage: If entry status is pending
+          and value date is present, then the value date
+          refers to an expected/requested value date. For
+          entries subject to availability/float and for which
+          availability information is provided, the value date
+          must not be used. In this case the availability
+          component identifies the  number of availability
+          days.
+
+          All dates in the JSON payloads are represented in
+          ISO 8601 date-time format.
+
+          All date-time fields in responses must include the
+          timezone. An example is below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      AddressLine:
+        description: >-
+          Information that locates and identifies a specific
+          address, as defined by postal services, that is
+          presented in free format text.
+        type: string
+        minLength: 1
+        maxLength: 70
+      BankTransactionCode:
+        description: >-
+          Set of elements used to fully identify the type of
+          underlying transaction resulting in an entry.
+        type: object
+        properties:
+          Code:
+            description: Specifies the family within a domain.
+            type: string
+          SubCode:
+            description: >-
+              Specifies the sub-product family within a
+              specific family.
+            type: string
+        required:
+          - Code
+          - SubCode
+        additionalProperties: false
+      ProprietaryBankTransactionCode:
+        description: >-
+          Set of elements to fully identify a proprietary bank
+          transaction code.
+        type: object
+        properties:
+          Code:
+            description: >-
+              Proprietary bank transaction code to identify
+              the underlying transaction.
+            type: string
+            minLength: 1
+            maxLength: 35
+          Issuer:
+            description: >-
+              Identification of the issuer of the proprietary
+              bank transaction code.
+            type: string
+            minLength: 1
+            maxLength: 35
+        required:
+          - Code
+        additionalProperties: false
+      CurrencyExchange:
+        description: Set of elements used to provide details on the currency exchange.
+        type: object
+        properties:
+          SourceCurrency:
+            description: >-
+              Currency from which an amount is to be converted in a currency
+              conversion.
+            type: string
+            pattern: "^[A-Z]{3,3}$"
+          TargetCurrency:
+            description: >-
+              Currency from which an amount is to be converted in a currency
+              conversion.
+            type: string
+            pattern: "^[A-Z]{3,3}$"
+          UnitCurrency:
+            description: >-
+              Currency from which an amount is to be converted in a currency
+              conversion.
+            type: string
+            pattern: "^[A-Z]{3,3}$"
+          ExchangeRate:
+            description: >-
+              Factor used to convert an amount from one currency into another. This
+              reflects the price at which one currency was bought with another
+              currency.
+
+              Usage: ExchangeRate expresses the ratio between UnitCurrency and
+              QuotedCurrency (ExchangeRate = UnitCurrency/QuotedCurrency).
+            type: number
+          ContractIdentification:
+            description: >-
+              Unique identification to unambiguously identify the foreign exchange
+              contract.
+            type: string
+            minLength: 1
+            maxLength: 35
+          QuotationDate:
+            description: >-
+              Date and time at which an exchange rate is quoted.
+
+              All dates in the JSON payloads are represented in ISO 8601 date-time
+              format.
+
+              All date-time fields in responses must include the timezone. An
+              example is below:
+
+              2017-04-05T10:43:07+00:00
+            type: string
+            format: date-time
+          InstructedAmount:
+            description: >-
+              Amount of money of the cash balance after a transaction entry is applied
+              to the account..
+            type: object
+            properties:
+              Amount:
+                description: >-
+                  A number of monetary units specified in an active currency where the unit
+                  of currency is explicit and compliant with ISO 4217.
+                type: string
+                pattern: '^\d{1,13}\.\d{1,5}$'
+              Currency:
+                description: >-
+                  A code allocated to a currency by a Maintenance Agency under an
+                  international identification scheme, as described in the latest
+                  edition of the international standard ISO 4217 "Codes for the
+                  representation of currencies and funds".
+                type: string
+                pattern: "^[A-Z]{3,3}$"
+            required:
+              - Amount
+              - Currency
+            additionalProperties: false
+        required:
+          - SourceCurrency
+          - ExchangeRate
+        additionalProperties: false
+      CreditorAgent:
+        type: object
+        properties:
+          SchemeName:
+            description: >-
+              Name of the identification scheme, in a coded form as published in
+              an external list.
+            type: string
+            enum:
+              - BICFI
+          Identification:
+            type: string
+            minLength: 1
+            maxLength: 35
+            description: >-
+              Unique and unambiguous identification of a financial institution
+              or a branch of a financial institution.
+        required:
+          - SchemeName
+          - Identification
+        additionalProperties: false
+        description: Financial institution servicing an account for the creditor.
+      DebtorAgent:
+        type: object
+        properties:
+          SchemeName:
+            description: >-
+              Name of the identification scheme, in a coded form as published in
+              an external list.
+            type: string
+            enum:
+              - BICFI
+          Identification:
+            type: string
+            minLength: 1
+            maxLength: 35
+            description: >-
+              Unique and unambiguous identification of a financial institution
+              or a branch of a financial institution.
+        required:
+          - SchemeName
+          - Identification
+        additionalProperties: false
+        description: Financial institution servicing an account for the debtor.
+      CardInstrument:
+        description: >-
+          Set of elements to describe the card instrument used in the
+          transaction.
+        type: object
+        properties:
+          CardSchemeName:
+            description: Name of the card scheme.
+            type: string
+            enum:
+              - AmericanExpress
+              - Diners
+              - Discover
+              - MasterCard
+              - VISA
+          AuthorisationType:
+            description: The card authorisation type.
+            type: string
+            enum:
+              - Contactless
+              - None
+              - PIN
+          Name:
+            description: Name of the cardholder using the card instrument.
+            type: string
+            minLength: 1
+            maxLength: 70
+          Identification:
+            description: >-
+              Identification assigned by an institution to identify the card
+              instrument used in the transaction. This identification is known
+              by the account owner, and may be masked.
+            type: string
+            minLength: 1
+            maxLength: 34
+        required:
+          - CardSchemeName
+        additionalProperties: false
+      TransactionInformation:
+        description: >-
+          Further details of the transaction. This is the
+          transaction narrative, which is unstructured text.
+        type: string
+        minLength: 1
+        maxLength: 500
+      Balance:
+        description: >-
+          Set of elements used to define the balance as a
+          numerical representation of the net increases and
+          decreases in an account after a transaction entry is
+          applied to the account.
+        type: object
+        properties:
+          Amount:
+            description: >-
+              Amount of money of the cash balance after a
+              transaction entry is applied to the account..
+            type: object
+            properties:
+              Amount:
+                type: string
+                pattern: '^\d{1,13}\.\d{1,5}$'
+              Currency:
+                description: >-
+                  A code allocated to a currency by a
+                  Maintenance Agency under an international
+                  identification scheme, as described in the
+                  latest edition of the international standard
+                  ISO 4217 'Codes for the representation of
+                  currencies and funds'
+                type: string
+                pattern: "^[A-Z]{3,3}$"
+            required:
+              - Amount
+              - Currency
+            additionalProperties: false
+          CreditDebitIndicator:
+            description: >-
+              Indicates whether the balance is a credit or a
+              debit balance. Usage: A zero balance is
+              considered to be a credit balance.
+            type: string
+            enum:
+              - Credit
+              - Debit
+          Type:
+            description: "Balance type, in a coded form."
+            type: string
+            enum:
+              - ClosingAvailable
+              - ClosingBooked
+              - Expected
+              - ForwardAvailable
+              - Information
+              - InterimAvailable
+              - InterimBooked
+              - OpeningAvailable
+              - OpeningBooked
+              - PreviouslyClosedBooked
+        required:
+          - Amount
+          - CreditDebitIndicator
+          - Type
+        additionalProperties: false
+      MerchantDetails:
+        description: Details of the merchant involved in the transaction.
+        type: object
+        properties:
+          MerchantName:
+            description: Name by which the merchant is known.
+            type: string
+            minLength: 1
+            maxLength: 350
+          MerchantCategoryCode:
+            description: >-
+              Category code conform to ISO 18245, related to
+              the type of services or goods the merchant
+              provides for the transaction.
+            type: string
+            minLength: 3
+            maxLength: 4
+        additionalProperties: false
+      CreditorAccount:
+        type: object
+        properties:
+          SchemeName:
+            $ref: "#/definitions/AccountSchemeModel"
+          Identification:
+            description: >-
+              Identification assigned by an institution to
+              identify an account. This identification is
+              known by the account owner.
+            type: string
+            minLength: 1
+            maxLength: 34
+          Name:
+            type: string
+            minLength: 1
+            maxLength: 70
+            description: >-
+              Name of the account, as assigned by the account servicing
+              institution, in agreement with the account owner in order to
+              provide an additional means of identification of the account.
+
+              Usage: The account name is different from the account owner name.
+              The account name is used in certain user communities to provide a
+              means of identifying the account, in addition to the account
+              owner's identity and the account number.
+          SecondaryIdentification:
+            type: string
+            minLength: 1
+            maxLength: 34
+            description: >-
+              This is secondary identification of the account, as assigned by
+              the account servicing institution.
+        required:
+          - SchemeName
+          - Identification
+        additionalProperties: false
+        description: >-
+          Unambiguous identification of the account of the creditor, in the case
+          of a debit transaction.
+      DebtorAccount:
+        type: object
+        properties:
+          SchemeName:
+            $ref: "#/definitions/AccountSchemeModel"
+          Identification:
+            description: >-
+              Identification assigned by an institution to
+              identify an account. This identification is
+              known by the account owner.
+            type: string
+            minLength: 1
+            maxLength: 34
+          Name:
+            type: string
+            minLength: 1
+            maxLength: 70
+            description: >-
+              Name of the account, as assigned by the account servicing
+              institution, in agreement with the account owner in order to
+              provide an additional means of identification of the account.
+
+              Usage: The account name is different from the account owner name.
+              The account name is used in certain user communities to provide a
+              means of identifying the account, in addition to the account
+              owner's identity and the account number.
+          SecondaryIdentification:
+            type: string
+            minLength: 1
+            maxLength: 34
+            description: >-
+              This is secondary identification of the account, as assigned by
+              the account servicing institution.
+        required:
+          - SchemeName
+          - Identification
+        additionalProperties: false
+        description: >-
+          Unambiguous identification of the account of the debtor, in the case
+          of a crebit transaction.
+    required:
+      - AccountId
+      - Amount
+      - CreditDebitIndicator
+      - Status
+      - BookingDateTime
+    additionalProperties: false
+  BeneficiaryModel:
+    type: object
+    properties:
+      AccountId:
+        description: >-
+          A unique and immutable identifier used to identify
+          the account resource. This identifier has no meaning
+          to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      BeneficiaryId:
+        description: >-
+          A unique and immutable identifier used to identify
+          the beneficiary resource. This identifier has no
+          meaning to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      Reference:
+        $ref: "#/definitions/BECSRemittance"
+      CreditorAgent:
+        description: >-
+          Party that manages the account on behalf of the account owner, that is
+          manages the registration and booking of entries on the account,
+          calculates balances on the account and provides information about the
+          account.
+
+          This is the servicer of the beneficiary account.
+        type: object
+        properties:
+          SchemeName:
+            description: >-
+              Name of the identification scheme, in a coded form as published in
+              an external list.
+            type: string
+            enum:
+              - BICFI
+          Identification:
+            description: >-
+              Unique and unambiguous identification of the servicing
+              institution.
+            type: string
+            minLength: 1
+            maxLength: 35
+          Name:
+            description: >-
+              Name by which an agent is known and which is usually used to
+              identify that agent.
+            type: string
+            minLength: 1
+            maxLength: 140
+          PostalAddress:
+            description: >-
+              Information that locates and identifies a specific address, as
+              defined by postal services.
+            type: object
+            properties:
+              AddressType:
+                description: Identifies the nature of the postal address.
+                type: string
+                enum:
+                  - Business
+                  - Correspondence
+                  - DeliveryTo
+                  - MailTo
+                  - POBox
+                  - Postal
+                  - Residential
+                  - Statement
+              AddressLine:
+                description: >-
+                  Information that locates and identifies a specific
+                  address, as defined by postal services, that is
+                  presented in free format text.
+                type: array
+                items:
+                  type: string
+                  minLength: 1
+                  maxLength: 70
+                minItems: 0
+                maxItems: 5
+              StreetName:
+                description: Name of a street or thoroughfare.
+                type: string
+                minLength: 1
+                maxLength: 70
+              BuildingNumber:
+                description: >-
+                  Number that identifies the position of a building on a street.
+                type: string
+                minLength: 1
+                maxLength: 16
+              PostCode:
+                description: >-
+                  Identifier consisting of a group of letters and/or numbers
+                  that is added to a postal address to assist the sorting of
+                  mail.
+                type: string
+                minLength: 1
+                maxLength: 16
+              TownName:
+                description: >-
+                  Name of a built-up area, with defined boundaries, and a local
+                  government.
+                type: string
+                minLength: 1
+                maxLength: 35
+              CountrySubDivision:
+                description: >-
+                  Identifies a subdivision of a country such as state, region,
+                  county.
+                type: string
+                minLength: 1
+                maxLength: 35
+              Country:
+                description: Nation with its own government.
+                type: string
+                pattern: "^[A-Z]{2,2}$"
+            required:
+              - Country
+            additionalProperties: false
+        additionalProperties: false
+      CreditorAccount:
+        description: >-
+          Provides the details to identify the beneficiary
+          account.
+        type: object
+        properties:
+          SchemeName:
+            $ref: "#/definitions/AccountSchemeModel"
+          Identification:
+            description: >-
+              Identification assigned by an institution to
+              identify an account. This identification is
+              known by the account owner.
+            type: string
+            minLength: 1
+            maxLength: 34
+          Name:
+            description: >-
+              Name of the account, as assigned by the account
+              servicing institution, in agreement with the
+              account owner in order to provide an additional
+              means of identification of the account. Usage:
+              The account name is different from the account
+              owner name. The account name is used in certain
+              user communities to provide a means of
+              identifying the account, in addition to the
+              account owner's identity and the account number.
+            type: string
+            minLength: 1
+            maxLength: 70
+          SecondaryIdentification:
+            description: >-
+              This is secondary identification of the account, as assigned by the
+              account servicing institution.
+            type: string
+            minLength: 1
+            maxLength: 34
+        required:
+          - SchemeName
+          - Identification
+        additionalProperties: false
+    required:
+      - AccountId
+    additionalProperties: false
+  StandingOrderModel:
+    type: object
+    properties:
+      AccountId:
+        description: >-
+          A unique and immutable identifier used to identify
+          the account resource. This identifier has no meaning
+          to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      StandingOrderId:
+        description: >-
+          A unique and immutable identifier used to identify
+          the standing order resource. This identifier has no
+          meaning to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      Frequency:
+        description: >
+          EvryDay - Every day
+
+          EvryWorkgDay - Every working day
+
+          IntrvlWkDay - An interval specified in weeks (01 to
+          09), and the day within the week (01 to 07)
+
+          WkInMnthDay - A monthly interval, specifying the
+          week of the month (01 to 05) and day within the week
+          (01 to 07)
+
+          IntrvlMnthDay - An interval specified in months
+          (between 01 to 06, 12, 24), specifying the day
+          within the month (-5 to -1, 1 to 31)
+
+
+          Patterns:
+
+          EvryDay (ScheduleCode)
+
+          EvryWorkgDay (ScheduleCode)
+
+          IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode
+          + IntervalInWeeks + DayInWeek)
+
+          WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode +
+          WeekInMonth + DayInWeek)
+
+          IntrvlMnthDay:IntervalInMonths:DayInMonth
+          (ScheduleCode + IntervalInMonths + DayInMonth)
+
+
+          The regular expression for this element combines
+          five smaller versions for each permitted pattern. To
+          aid legibility - the components are presented
+          individually here:
+
+          EvryDay
+
+          EvryWorkgDay
+
+          IntrvlWkDay:0[1-9]:0[1-7]
+
+          WkInMnthDay:0[1-5]:0[1-7]
+
+          IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01])
+
+        type: string
+        pattern: >-
+          ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$
+      Reference:
+        $ref: "#/definitions/BECSRemittance"
+      FirstPaymentDateTime:
+        description: >-
+          The date on which the first payment for a Standing
+          Order schedule will be made.
+
+          All dates in the JSON payloads are represented in
+          ISO 8601 date-time format.
+
+          All date-time fields in responses must include the
+          timezone. An example is below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      FirstPaymentAmount:
+        description: The amount of the first Standing Order
+        type: object
+        properties:
+          Amount:
+            type: string
+            pattern: '^\d{1,13}\.\d{1,5}$'
+          Currency:
+            description: >-
+              A code allocated to a currency by a Maintenance
+              Agency under an international identification
+              scheme, as described in the latest edition of
+              the international standard ISO 4217 'Codes for
+              the representation of currencies and funds'
+            type: string
+            pattern: "^[A-Z]{3,3}$"
+        required:
+          - Amount
+          - Currency
+        additionalProperties: false
+      NextPaymentDateTime:
+        description: >-
+          The date on which the next payment for a Standing
+          Order schedule will be made.
+
+          All dates in the JSON payloads are represented in
+          ISO 8601 date-time format.
+
+          All date-time fields in responses must include the
+          timezone. An example is below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      NextPaymentAmount:
+        description: The amount of the next Standing Order
+        type: object
+        properties:
+          Amount:
+            type: string
+            pattern: '^\d{1,13}\.\d{1,5}$'
+          Currency:
+            description: >-
+              A code allocated to a currency by a Maintenance
+              Agency under an international identification
+              scheme, as described in the latest edition of
+              the international standard ISO 4217 'Codes for
+              the representation of currencies and funds'
+            type: string
+            pattern: "^[A-Z]{3,3}$"
+        required:
+          - Amount
+          - Currency
+        additionalProperties: false
+      FinalPaymentDateTime:
+        description: >-
+          The date on which the final payment for a Standing
+          Order schedule will be made.
+
+          All dates in the JSON payloads are represented in
+          ISO 8601 date-time format.
+
+          All date-time fields in responses must include the
+          timezone. An example is below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      FinalPaymentAmount:
+        description: The amount of the final Standing Order
+        type: object
+        properties:
+          Amount:
+            type: string
+            pattern: '^\d{1,13}\.\d{1,5}$'
+          Currency:
+            description: >-
+              A code allocated to a currency by a Maintenance
+              Agency under an international identification
+              scheme, as described in the latest edition of
+              the international standard ISO 4217 'Codes for
+              the representation of currencies and funds'
+            type: string
+            pattern: "^[A-Z]{3,3}$"
+        required:
+          - Amount
+          - Currency
+        additionalProperties: false
+      StandingOrderStatusCode:
+        description: Specifies the status of the standing order in code form.
+        type: string
+        enum:
+          - Active
+          - Inactive
+      CreditorAgent:
+        description: >-
+          Party that manages the account on behalf of the
+          account owner, that is manages the registration and
+          booking of entries on the account, calculates
+          balances on the account and provides information
+          about the account. This is the servicer of the
+          beneficiary account
+        type: object
+        properties:
+          SchemeName:
+            description: >-
+              Name of the identification scheme, in a coded
+              form as published in an external list.
+            type: string
+            enum:
+              - BICFI
+          Identification:
+            description: >-
+              Unique and unambiguous identification of the
+              servicing institution.
+            type: string
+            minLength: 1
+            maxLength: 35
+        required:
+          - SchemeName
+          - Identification
+        additionalProperties: false
+      CreditorAccount:
+        description: >-
+          Provides the details to identify the beneficiary
+          account.
+        type: object
+        properties:
+          SchemeName:
+            $ref: "#/definitions/AccountSchemeModel"
+          Identification:
+            description: >-
+              Identification assigned by an institution to
+              identify an account. This identification is
+              known by the account owner.
+            type: string
+            minLength: 1
+            maxLength: 34
+          Name:
+            description: >-
+              Name of the account, as assigned by the account
+              servicing institution, in agreement with the
+              account owner in order to provide an additional
+              means of identification of the account. Usage:
+              The account name is different from the account
+              owner name. The account name is used in certain
+              user communities to provide a means of
+              identifying the account, in addition to the
+              account owner's identity and the account number.
+            type: string
+            minLength: 1
+            maxLength: 70
+          SecondaryIdentification:
+            description: >-
+              This is secondary identification of the account,
+              as assigned by the account servicing institution.
+            type: string
+            minLength: 1
+            maxLength: 34
+        required:
+          - SchemeName
+          - Identification
+        additionalProperties: false
+    required:
+      - AccountId
+      - Frequency
+      - NextPaymentDateTime
+      - NextPaymentAmount
+    additionalProperties: false
+  DirectDebitModel:
+    type: object
+    properties:
+      AccountId:
+        description: >-
+          A unique and immutable identifier used to identify
+          the account resource. This identifier has no meaning
+          to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      DirectDebitId:
+        description: >-
+          A unique and immutable identifier used to identify
+          the direct debit resource. This identifier has no
+          meaning to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      MandateIdentification:
+        description: >-
+          Direct Debit reference.
+        type: string
+        minLength: 1
+        maxLength: 35
+      DirectDebitStatusCode:
+        description: >-
+          Specifies the status of the direct debit in code
+          form.
+        type: string
+        enum:
+          - Active
+          - Inactive
+      Name:
+        description: Name of Service User
+        type: string
+        minLength: 1
+        maxLength: 70
+      PreviousPaymentDateTime:
+        description: >-
+          Date of most recent direct debit collection.
+
+          All dates in the JSON payloads are represented in
+          ISO 8601 date-time format.
+
+          All date-time fields in responses must include the
+          timezone. An example is below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      PreviousPaymentAmount:
+        description: >-
+          The amount of the most recent direct debit
+          collection.
+        type: object
+        properties:
+          Amount:
+            type: string
+            pattern: '^\d{1,13}\.\d{1,5}$'
+          Currency:
+            description: >-
+              A code allocated to a currency by a Maintenance
+              Agency under an international identification
+              scheme, as described in the latest edition of
+              the international standard ISO 4217 'Codes for
+              the representation of currencies and funds'
+            type: string
+            pattern: "^[A-Z]{3,3}$"
+        required:
+          - Amount
+          - Currency
+        additionalProperties: false
+    required:
+      - AccountId
+      - MandateIdentification
+      - Name
+    additionalProperties: false
+  OfferModel:
+    type: object
+    properties:
+      AccountId:
+        description: >-
+          A unique and immutable identifier used to identify
+          the account resource. This identifier has no meaning
+          to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      OfferId:
+        description: >-
+          A unique and immutable identifier used to identify the offer resource.
+          This identifier has no meaning to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      OfferType:
+        description: "Offer type, in a coded form."
+        type: string
+        enum:
+          - BalanceTransfer
+          - LimitIncrease
+          - MoneyTransfer
+          - Other
+          - PromotionalRate
+      Description:
+        description: Further details of the offer.
+        type: string
+        minLength: 1
+        maxLength: 500
+      StartDateTime:
+        description: >-
+          Date and time at which the offer starts.
+
+          All dates in the JSON payloads are represented in ISO 8601 date-time
+          format.
+
+          All date-time fields in responses must include the timezone. An
+          example is below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      EndDateTime:
+        description: >-
+          Date and time at which the offer ends.
+
+          All dates in the JSON payloads are represented in ISO 8601 date-time
+          format.
+
+          All date-time fields in responses must include the timezone. An
+          example is below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      Amount:
+        description: Amount of money associated with the offer type.
+        type: object
+        properties:
+          Amount:
+            type: string
+            pattern: '^\d{1,13}\.\d{1,5}$'
+          Currency:
+            description: >-
+              A code allocated to a currency by a Maintenance Agency under an
+              international identification scheme, as described in the latest
+              edition of the international standard ISO 4217 "Codes for the
+              representation of currencies and funds".
+            type: string
+            pattern: "^[A-Z]{3,3}$"
+        required:
+          - Amount
+          - Currency
+        additionalProperties: false
+      Fee:
+        description: Fee associated with the offer type.
+        type: object
+        properties:
+          Amount:
+            type: string
+            pattern: '^\d{1,13}\.\d{1,5}$'
+          Currency:
+            description: >-
+              A code allocated to a currency by a Maintenance Agency under an
+              international identification scheme, as described in the latest
+              edition of the international standard ISO 4217 "Codes for the
+              representation of currencies and funds".
+            type: string
+            pattern: "^[A-Z]{3,3}$"
+        required:
+          - Amount
+          - Currency
+        additionalProperties: false
+      Rate:
+        description: Rate associated with the offer type.
+        type: string
+        minLength: 1
+        maxLength: 10
+        pattern: '^(-?\d{1,3}){1}(\.\d{1,4}){0,1}$'
+      Value:
+        description: Value associated with the offer type.
+        type: integer
+        format: int32
+      Term:
+        description: Further details of the term of the offer.
+        type: string
+        minLength: 1
+        maxLength: 500
+      URL:
+        description: URL (Uniform Resource Locator) where the document can be found
+        type: string
+        minLength: 1
+        maxLength: 256
+    required:
+      - AccountId
+    additionalProperties: false
+  PartyModel:
+    type: object
+    properties:
+      PartyId:
+        description: >-
+          A unique and immutable identifier used to identify the customer
+          resource. This identifier has no meaning to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      PartyNumber:
+        description: Number assigned by an agent to identify its customer.
+        type: string
+        minLength: 1
+        maxLength: 35
+      PartyType:
+        description: "Party type, in a coded form."
+        type: string
+        enum:
+          - Delegate
+          - Joint
+          - Sole
+      Name:
+        description: >-
+          Name by which a party is known and which is usually used to identify
+          that party.
+        type: string
+        minLength: 1
+        maxLength: 70
+      EmailAddress:
+        description: Address for electronic mail (e-mail).
+        type: string
+        minLength: 1
+        maxLength: 256
+      Phone:
+        description: >-
+          Collection of information that identifies a phone number, as defined
+          by telecom services.
+        type: string
+        pattern: '\+[0-9]{1,3}-[0-9()+\-]{1,30}'
+      Mobile:
+        description: >-
+          Collection of information that identifies a mobile phone number, as
+          defined by telecom services.
+        type: string
+        pattern: '\+[0-9]{1,3}-[0-9()+\-]{1,30}'
+      Address:
+        type: array
+        description: Postal address of a party.
+        items:
+          description: Postal address of a party.
+          type: object
+          properties:
+            AddressType:
+              description: Identifies the nature of the postal address.
+              type: string
+              enum:
+                - Business
+                - Correspondence
+                - DeliveryTo
+                - MailTo
+                - POBox
+                - Postal
+                - Residential
+                - Statement
+            AddressLine:
+              description: >-
+                Information that locates and identifies a specific
+                address, as defined by postal services, that is
+                presented in free format text.
+              type: array
+              items:
+                type: string
+                minLength: 1
+                maxLength: 70
+              minItems: 0
+              maxItems: 5
+            StreetName:
+              description: >-
+                Name of a street or thoroughfare.
+              type: string
+              minLength: 1
+              maxLength: 70
+            BuildingNumber:
+              description: >-
+                Number that identifies the position of a building on a street.
+              type: string
+              minLength: 1
+              maxLength: 16
+            PostCode:
+              description: >-
+                Identifier consisting of a group of letters and/or numbers that is
+                added to a postal address to assist the sorting of mail.
+              type: string
+              minLength: 1
+              maxLength: 16
+            TownName:
+              description: >-
+                Name of a built-up area, with defined boundaries, and a local
+                government.
+              type: string
+              minLength: 1
+              maxLength: 35
+            CountrySubDivision:
+              description: >-
+                Identifies a subdivision of a country eg, state, region, county.
+              type: string
+              minLength: 1
+              maxLength: 35
+            Country:
+              description: >-
+                Nation with its own government, occupying a particular territory.
+              type: string
+              pattern: "^[A-Z]{2,2}$"
+          required:
+            - Country
+          additionalProperties: false
+    required:
+      - PartyId
+    additionalProperties: false
+  ScheduledPaymentModel:
+    type: object
+    properties:
+      AccountId:
+        description: >-
+          A unique and immutable identifier used to identify the account
+          resource. This identifier has no meaning to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      ScheduledPaymentId:
+        description: >-
+          A unique and immutable identifier used to identify the scheduled
+          payment resource. This identifier has no meaning to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      ScheduledPaymentDateTime:
+        description: >-
+          The date on which the scheduled payment will be made.
+
+          All dates in the JSON payloads are represented in ISO 8601 date-time
+          format.
+
+          All date-time fields in responses must include the timezone. An
+          example is below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      ScheduledType:
+        description: Specifies the scheduled payment date type requested
+        type: string
+        enum:
+          - Arrival
+          - Execution
+      InstructedAmount:
+        description: >-
+          Amount of money to be moved between the debtor and creditor, before
+          deduction of charges, expressed in the currency as ordered by the
+          initiating party.
+
+          Usage: This amount has to be transported unchanged through the
+          transaction chain.
+        type: object
+        properties:
+          Amount:
+            type: string
+            pattern: '^\d{1,13}\.\d{1,5}$'
+          Currency:
+            description: >-
+              A code allocated to a currency by a Maintenance Agency under an
+              international identification scheme, as described in the latest
+              edition of the international standard ISO 4217 "Codes for the
+              representation of currencies and funds".
+            type: string
+            pattern: "^[A-Z]{3,3}$"
+        required:
+          - Amount
+          - Currency
+        additionalProperties: false
+      Reference:
+        $ref: "#/definitions/BECSRemittance"
+      CreditorAgent:
+        type: object
+        properties:
+          SchemeName:
+            description: >-
+              Name of the identification scheme, in a coded form as published in
+              an external list.
+            type: string
+            enum:
+              - BICFI
+          Identification:
+            type: string
+            minLength: 1
+            maxLength: 35
+            description: >-
+              Unique and unambiguous identification of a financial institution
+              or a branch of a financial institution.
+        required:
+          - SchemeName
+          - Identification
+        additionalProperties: false
+        description: Financial institution servicing an account for the creditor.
+      CreditorAccount:
+        type: object
+        properties:
+          SchemeName:
+            $ref: "#/definitions/AccountSchemeModel"
+          Identification:
+            description: >-
+              Identification assigned by an institution to
+              identify an account. This identification is
+              known by the account owner.
+            type: string
+            minLength: 1
+            maxLength: 34
+          Name:
+            type: string
+            minLength: 1
+            maxLength: 70
+            description: >-
+              Name of the account, as assigned by the account servicing
+              institution, in agreement with the account owner in order to
+              provide an additional means of identification of the account.
+
+              Usage: The account name is different from the account owner name.
+              The account name is used in certain user communities to provide a
+              means of identifying the account, in addition to the account
+              owner's identity and the account number.
+          SecondaryIdentification:
+            type: string
+            minLength: 1
+            maxLength: 34
+            description: >-
+              This is secondary identification of the account, as assigned by
+              the account servicing institution.
+        required:
+          - SchemeName
+          - Identification
+        additionalProperties: false
+        description: Provides the details to identify the beneficiary account.
+    required:
+      - AccountId
+      - ScheduledPaymentDateTime
+      - ScheduledType
+      - InstructedAmount
+    additionalProperties: false
+  StatementModel:
+    description: Provides further details on a statement resource.
+    type: object
+    properties:
+      AccountId:
+        description: >-
+          A unique and immutable identifier used to identify the account
+          resource. This identifier has no meaning to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      StatementId:
+        description: >-
+          Unique identifier for the statement resource within an servicing
+          institution. This identifier is both unique and immutable.
+        type: string
+        minLength: 1
+        maxLength: 40
+      StatementReference:
+        description: >-
+          Unique reference for the statement. This reference may be optionally
+          populated if available.
+        type: string
+        minLength: 1
+        maxLength: 35
+      Type:
+        description: "Statement type, in a coded form."
+        type: string
+        enum:
+          - AccountClosure
+          - AccountOpening
+          - Annual
+          - Interim
+          - RegularPeriodic
+      StartDateTime:
+        description: >-
+          Date and time at which the statement period starts.
+
+          All dates in the JSON payloads are represented in ISO 8601 date-time
+          format.
+
+          All date-time fields in responses must include the timezone. An
+          example is below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      EndDateTime:
+        description: >-
+          Date and time at which the statement period ends.
+
+          All dates in the JSON payloads are represented in ISO 8601 date-time
+          format.
+
+          All date-time fields in responses must include the timezone. An
+          example is below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      CreationDateTime:
+        description: >-
+          Date and time at which the resource was created.
+
+          All dates in the JSON payloads are represented in ISO 8601 date-time
+          format.
+
+          All date-time fields in responses must include the timezone. An
+          example is below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      StatementDescription:
+        items:
+          description: >-
+            Other descriptions that may be available for the statement resource.
+          type: string
+          minLength: 1
+          maxLength: 500
+        type: array
+        description: >-
+          Other descriptions that may be available for the statement resource.
+      StatementBenefit:
+        type: array
+        description: >-
+          Set of elements used to provide details of a benefit or reward amount
+          for the statement resource.
+        items:
+          description: >-
+            Set of elements used to provide details of a benefit or reward
+            amount for the statement resource.
+          type: object
+          properties:
+            Amount:
+              description: Amount of money associated with the statement benefit type.
+              type: object
+              properties:
+                Amount:
+                  type: string
+                  pattern: '^\d{1,13}\.\d{1,5}$'
+                Currency:
+                  description: >-
+                    A code allocated to a currency by a Maintenance Agency under
+                    an international identification scheme, as described in the
+                    latest edition of the international standard ISO 4217 "Codes
+                    for the representation of currencies and funds".
+                  type: string
+                  pattern: "^[A-Z]{3,3}$"
+              required:
+                - Amount
+                - Currency
+              additionalProperties: false
+            Type:
+              description: "Benefit type, in a coded form."
+              type: string
+              enum:
+                - Cashback
+                - Insurance
+                - TravelDiscount
+                - TravelInsurance
+          required:
+            - Amount
+            - Type
+          additionalProperties: false
+      StatementFee:
+        type: array
+        description: >-
+          Set of elements used to provide details of a fee for the statement
+          resource.
+        items:
+          description: >-
+            Set of elements used to provide details of a fee for the statement
+            resource.
+          type: object
+          properties:
+            Amount:
+              description: Amount of money associated with the statement fee type.
+              type: object
+              properties:
+                Amount:
+                  type: string
+                  pattern: '^\d{1,13}\.\d{1,5}$'
+                Currency:
+                  description: >-
+                    A code allocated to a currency by a Maintenance Agency under
+                    an international identification scheme, as described in the
+                    latest edition of the international standard ISO 4217 "Codes
+                    for the representation of currencies and funds".
+                  type: string
+                  pattern: "^[A-Z]{3,3}$"
+              required:
+                - Amount
+                - Currency
+              additionalProperties: false
+            CreditDebitIndicator:
+              type: string
+              enum:
+                - Credit
+                - Debit
+              description: >-
+                Indicates whether the amount is a credit or a debit.
+                Usage: A zero amount is considered to be a credit amount.
+            Type:
+              description: "Fee type, in a coded form."
+              type: string
+              enum:
+                - Annual
+                - BalanceTransfer
+                - CashAdvance
+                - CashTransaction
+                - ForeignTransaction
+                - Gambling
+                - LatePayment
+                - MoneyTransfer
+                - Monthly
+                - Overlimit
+                - PostalOrder
+                - PrizeEntry
+                - StatementCopy
+                - Total
+          required:
+            - Amount
+            - CreditDebitIndicator
+            - Type
+          additionalProperties: false
+      StatementInterest:
+        type: array
+        description: >-
+          Set of elements used to provide details of a generic interest amount
+          related to the statement resource.
+        items:
+          description: >-
+            Set of elements used to provide details of a generic interest amount
+            related to the statement resource.
+          type: object
+          properties:
+            Amount:
+              description: >-
+                Amount of money associated with the statement interest amount
+                type.
+              type: object
+              properties:
+                Amount:
+                  type: string
+                  pattern: '^\d{1,13}\.\d{1,5}$'
+                Currency:
+                  description: >-
+                    A code allocated to a currency by a Maintenance Agency under
+                    an international identification scheme, as described in the
+                    latest edition of the international standard ISO 4217 "Codes
+                    for the representation of currencies and funds".
+                  type: string
+                  pattern: "^[A-Z]{3,3}$"
+              required:
+                - Amount
+                - Currency
+              additionalProperties: false
+            CreditDebitIndicator:
+              type: string
+              enum:
+                - Credit
+                - Debit
+              description: >-
+                Indicates whether the amount is a credit or a debit.
+                Usage: A zero amount is considered to be a credit amount.
+            Type:
+              description: "Interest amount type, in a coded form."
+              type: string
+              enum:
+                - BalanceTransfer
+                - Cash
+                - EstimatedNext
+                - Purchase
+                - Total
+          required:
+            - Amount
+            - CreditDebitIndicator
+            - Type
+          additionalProperties: false
+      StatementDateTime:
+        type: array
+        description: >-
+          Set of elements used to provide details of a generic date time for the
+          statement resource.
+        items:
+          description: >-
+            Set of elements used to provide details of a generic date time for
+            the statement resource.
+          type: object
+          properties:
+            DateTime:
+              description: >-
+                Date and time associated with the date time type.
+
+                All dates in the JSON payloads are represented in ISO 8601
+                date-time format.
+
+                All date-time fields in responses must include the timezone. An
+                example is below:
+
+                2017-04-05T10:43:07+00:00
+              type: string
+              format: date-time
+            Type:
+              description: "Date time type, in a coded form."
+              type: string
+              enum:
+                - BalanceTransferPromoEnd
+                - DirectDebitDue
+                - LastPayment
+                - LastStatement
+                - NextStatement
+                - PaymentDue
+                - PurchasePromoEnd
+                - StatementAvailable
+          required:
+            - DateTime
+            - Type
+          additionalProperties: false
+      StatementRate:
+        type: array
+        description: >-
+          Set of elements used to provide details of a generic rate related to
+          the statement resource.
+        items:
+          description: >-
+            Set of elements used to provide details of a generic rate related to
+            the statement resource.
+          type: object
+          properties:
+            Rate:
+              description: Rate associated with the statement rate type.
+              type: string
+              minLength: 1
+              maxLength: 10
+              pattern: '^(-?\d{1,3}){1}(\.\d{1,4}){0,1}$'
+            Type:
+              description: "Statement rate type, in a coded form."
+              type: string
+              enum:
+                - AnnualBalanceTransfer
+                - AnnualBalanceTransferAfterPromo
+                - AnnualBalanceTransferPromo
+                - AnnualCash
+                - AnnualPurchase
+                - AnnualPurchaseAfterPromo
+                - AnnualPurchasePromo
+                - MonthlyBalanceTransfer
+                - MonthlyCash
+                - MonthlyPurchase
+          required:
+            - Rate
+            - Type
+          additionalProperties: false
+      StatementValue:
+        type: array
+        description: >-
+          Set of elements used to provide details of a generic number value
+          related to the statement resource.
+        items:
+          description: >-
+            Set of elements used to provide details of a generic number value
+            related to the statement resource.
+          type: object
+          properties:
+            Value:
+              description: Value associated with the statement value type.
+              type: integer
+              format: int32
+            Type:
+              description: "Statement value type, in a coded form."
+              type: string
+              enum:
+                - AirMilesPoints
+                - AirMilesPointsBalance
+                - Credits
+                - Debits
+                - HotelPoints
+                - HotelPointsBalance
+                - RetailShoppingPoints
+                - RetailShoppingPointsBalance
+          required:
+            - Value
+            - Type
+          additionalProperties: false
+      StatementAmount:
+        type: array
+        description: >-
+          Set of elements used to provide details of a generic amount for the
+          statement resource.
+        items:
+          description: >-
+            Set of elements used to provide details of a generic amount for the
+            statement resource.
+          type: object
+          properties:
+            Amount:
+              description: Amount of money associated with the amount type.
+              type: object
+              properties:
+                Amount:
+                  type: string
+                  pattern: '^\d{1,13}\.\d{1,5}$'
+                Currency:
+                  description: >-
+                    A code allocated to a currency by a Maintenance Agency under
+                    an international identification scheme, as described in the
+                    latest edition of the international standard ISO 4217 "Codes
+                    for the representation of currencies and funds".
+                  type: string
+                  pattern: "^[A-Z]{3,3}$"
+              required:
+                - Amount
+                - Currency
+              additionalProperties: false
+            CreditDebitIndicator:
+              type: string
+              enum:
+                - Credit
+                - Debit
+              description: >-
+                Indicates whether the amount is a credit or a debit.
+                Usage: A zero amount is considered to be a credit amount.
+            Type:
+              description: "Amount type, in a coded form."
+              type: string
+              enum:
+                - ArrearsClosingBalance
+                - AvailableBalance
+                - AverageBalanceWhenInCredit
+                - AverageBalanceWhenInDebit
+                - AverageDailyBalance
+                - BalanceTransferClosingBalance
+                - CashClosingBalance
+                - ClosingBalance
+                - CreditLimit
+                - CurrentPayment
+                - DirectDebitPaymentDue
+                - MinimumPaymentDue
+                - PreviousClosingBalance
+                - PreviousPayment
+                - PurchaseClosingBalance
+                - StartingBalance
+                - TotalAdjustments
+                - TotalCashAdvances
+                - TotalCharges
+                - TotalCredits
+                - TotalDebits
+                - TotalPurchases
+          required:
+            - Amount
+            - CreditDebitIndicator
+            - Type
+          additionalProperties: false
+    required:
+      - AccountId
+      - Type
+      - StartDateTime
+      - EndDateTime
+      - CreationDateTime
+    additionalProperties: false
+  BECSRemittance:
+    type: object
+    description: >-
+      Unique reference, as assigned by the creditor, to
+      unambiguously refer to the payment transaction.
+      Usage: If available, the initiating party should
+      provide this reference in the structured remittance
+      information, to enable reconciliation by the
+      creditor upon receipt of the amount of money. If the
+      business context requires the use of a creditor
+      reference or a payment remit identification, and
+      only one identifier can be passed through the
+      end-to-end chain, the creditor's reference or
+      payment remittance identification should be quoted
+      in the end-to-end transaction identification.
+
+      NZ - Remittance information for use with BECS Electronic Credit payment scheme.
+      The Particulars, Code and Reference fields are currently constrained by
+      providers.  The design choice has been made not to constrain through schema
+      restrictions, to allow for future changes that remove the constraint.
+      Note that not all banks will accept all valid characters, in which case a
+      descriptive 400 Bad Request will be returned. Constraining to a-z, A-Z, -
+      (dash) and 0-9 is advised. One example is abc-XYZ-123
+    properties:
+      CreditorName:
+        type: string
+        maxLength: 20
+      CreditorReference:
+        type: object
+        properties:
+          Particulars:
+            type: string
+            maxLength: 12
+          Code:
+            type: string
+            maxLength: 12
+          Reference:
+            type: string
+            maxLength: 12
+        additionalProperties: false
+      DebtorName:
+        type: string
+        maxLength: 20
+      DebtorReference:
+        type: object
+        properties:
+          Particulars:
+            type: string
+            maxLength: 12
+          Code:
+            type: string
+            maxLength: 12
+          Reference:
+            type: string
+            maxLength: 12
+        additionalProperties: false
+    required:
+      - CreditorName
+    additionalProperties: false
+  Meta:
+    title: MetaData
+    type: object
+    description: Meta Data relevant to the payload
+    properties:
+      TotalPages:
+        type: integer
+        format: int32
+      FirstAvailableDateTime:
+        description: >-
+          All dates in the JSON payloads are represented in ISO 8601 date-time
+          format.
+
+          All date-time fields in responses must include the timezone. An example is
+          below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      LastAvailableDateTime:
+        description: >-
+          All dates in the JSON payloads are represented in ISO 8601 date-time
+          format.
+
+          All date-time fields in responses must include the timezone. An example is
+          below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+    additionalProperties: false
+securityDefinitions:
+  CustomerOAuth2Security:
+    type: oauth2
+    flow: accessCode
+    tokenUrl: "https://authserver.example/token"
+    authorizationUrl: "https://authserver.example/authorization"
+    scopes:
+      accounts: Ability to read accounts information
+    description: >-
+      OAuth flow, it is required when the Customer needs to perform SCA with the
+      API Provider when a Third Party wants to access an API Provider resource owned
+      by the Customer
+  ThirdPartyOAuth2Security:
+    type: oauth2
+    flow: application
+    tokenUrl: "https://authserver.example/token"
+    scopes:
+      accounts: Ability to read accounts information
+    description: >-
+      Third Party client credential authorisation flow with the API Provider
+responses:
+  400ErrorResponse:
+    description: Bad Request
+    headers:
+      x-fapi-interaction-id:
+        type: string
+        description: An RFC4122 UID used as a correlation id.
+    schema:
+      $ref: "#/definitions/ErrorResponse"
+  401ErrorResponse:
+    description: Unauthorized
+    headers:
+      x-fapi-interaction-id:
+        type: string
+        description: An RFC4122 UID used as a correlation id.
+  403ErrorResponse:
+    description: Forbidden
+    headers:
+      x-fapi-interaction-id:
+        type: string
+        description: An RFC4122 UID used as a correlation id.
+    schema:
+      $ref: "#/definitions/ErrorResponse"
+  405ErrorResponse:
+    description: Method Not Allowed
+    headers:
+      x-fapi-interaction-id:
+        type: string
+        description: An RFC4122 UID used as a correlation id.
+  406ErrorResponse:
+    description: Not Acceptable
+    headers:
+      x-fapi-interaction-id:
+        type: string
+        description: An RFC4122 UID used as a correlation id.
+  415ErrorResponse:
+    description: Unsupported Media Type
+    headers:
+      x-fapi-interaction-id:
+        type: string
+        description: An RFC4122 UID used as a correlation id.
+  429ErrorResponse:
+    description: Too Many Requests
+    headers:
+      Retry-After:
+        description: Number in seconds to wait
+        type: integer
+      x-fapi-interaction-id:
+        type: string
+        description: An RFC4122 UID used as a correlation id.
+  500ErrorResponse:
+    description: Internal Server Error
+    headers:
+      x-fapi-interaction-id:
+        type: string
+        description: An RFC4122 UID used as a correlation id.
+    schema:
+      $ref: "#/definitions/ErrorResponse"
+  501ErrorResponse:
+    description: Not Implemented
+    headers:
+      x-fapi-interaction-id:
+        type: string
+        description: An RFC4122 UID used as a correlation id.
+  503ErrorResponse:
+    description: Service Unavailable
+    headers:
+      x-fapi-interaction-id:
+        type: string
+        description: An RFC4122 UID used as a correlation id.
+    schema:
+      $ref: "#/definitions/ErrorResponse"


### PR DESCRIPTION
[Technical decision 029](https://paymentsnz.atlassian.net/wiki/spaces/PaymentsDirectionAPIStandardsDevelopment/pages/1455358006/Technical+Decision+-+029+-+Error+Response+Body+Inconsistency) determined that error response body should be included in all non-success HTTP responses.  This was unfortunately not reflected in the Swagger specifications and this patch corrects that omission.